### PR TITLE
chore: pin workflow actions, refresh tool versions, and update Node examples

### DIFF
--- a/.github/actions/setup-npm/action.yml
+++ b/.github/actions/setup-npm/action.yml
@@ -9,7 +9,7 @@ runs:
     shell: bash
 
   - name: Cache pnpm store
-    uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae
+    uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
     with:
       path: ${{ env.STORE_PATH }}
       key: pnpm-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -19,5 +19,5 @@ jobs:
   actionlint:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
-    - uses: rhysd/actionlint@011a6d15e749bb3f2d771eed9c7aa0e7e3e10ee7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+    - uses: rhysd/actionlint@914e7df21a07ef503a81201c76d2b11c789d3fca

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -9,7 +9,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
     - name: Setup Tools
       uses: ./.github/actions/setup-tools

--- a/.github/workflows/release-tag-changelog.yml
+++ b/.github/workflows/release-tag-changelog.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       with:
         ssh-key: ${{ secrets.SSH_KEY }}
         fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,9 @@ jobs:
       contents: write
 
     steps:
-    - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
     - name: Release
-      uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe
+      uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-asdf-tools.yml
+++ b/.github/workflows/test-asdf-tools.yml
@@ -30,8 +30,8 @@ jobs:
           runner: macos-14
     runs-on: ${{ matrix.platform.runner }}
     steps:
-    - uses: hmarr/debug-action@f7318c783045ac39ed9bb497e22ce835fdafbfe6
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+    - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
     - name: Install asdf tools in another directory
       uses: ./asdf-tools

--- a/.github/workflows/test-docker-build-push.yml
+++ b/.github/workflows/test-docker-build-push.yml
@@ -28,7 +28,7 @@ jobs:
       IMAGE_TAG: test-${{ github.run_id }}
 
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
     - name: Compute image name
       id: image

--- a/.github/workflows/test-npm-packages.yml
+++ b/.github/workflows/test-npm-packages.yml
@@ -19,9 +19,9 @@ jobs:
   npm-packages-test:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
       with:
         node-version: '20'
 

--- a/.github/workflows/test-npm-packages.yml
+++ b/.github/workflows/test-npm-packages.yml
@@ -23,7 +23,7 @@ jobs:
 
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
       with:
-        node-version: '20'
+        node-version: '26'
 
     - name: Install package fixtures
       uses: ./npm-packages

--- a/.github/workflows/test-pnpm-packages.yml
+++ b/.github/workflows/test-pnpm-packages.yml
@@ -23,7 +23,7 @@ jobs:
 
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
       with:
-        node-version: '20'
+        node-version: '26'
 
     - name: Enable Corepack
       run: corepack enable

--- a/.github/workflows/test-pnpm-packages.yml
+++ b/.github/workflows/test-pnpm-packages.yml
@@ -19,9 +19,9 @@ jobs:
   pnpm-packages-test:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
       with:
         node-version: '20'
 

--- a/.github/workflows/test-precommit.yml
+++ b/.github/workflows/test-precommit.yml
@@ -19,9 +19,9 @@ jobs:
   precommit-pass:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
       with:
         python-version: '3.12'
 
@@ -38,9 +38,9 @@ jobs:
   precommit-fails-on-autofix-when-commit-disabled:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
       with:
         python-version: '3.12'
 

--- a/.github/workflows/test-yarn-packages.yml
+++ b/.github/workflows/test-yarn-packages.yml
@@ -23,7 +23,7 @@ jobs:
 
     - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
       with:
-        node-version: '20'
+        node-version: '26'
 
     - name: Enable Corepack
       run: corepack enable

--- a/.github/workflows/test-yarn-packages.yml
+++ b/.github/workflows/test-yarn-packages.yml
@@ -19,9 +19,9 @@ jobs:
   yarn-packages-test:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
       with:
         node-version: '20'
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,7 +1,7 @@
-nodejs 25.9.0
-python 3.14.4
-pnpm 11.0.3
-act 0.2.88
+nodejs 26.4.0
+python 3.14.6
+pnpm 11.10.0
+act 0.2.89
 actionlint 1.7.12
 shellcheck 0.11.0
 shfmt 3.13.1

--- a/asdf-tools/action.yml
+++ b/asdf-tools/action.yml
@@ -61,7 +61,7 @@ runs:
     uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
     with:
       path: ~/.asdf
-      key: ${{ runner.os }}-${{ inputs.version }}-${{ hashFiles('**/.tool-versions') }}
+      key: ${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}-${{ hashFiles('**/.tool-versions') }}
 
   - name: Install asdf tools
     run: |

--- a/npm-packages/README.md
+++ b/npm-packages/README.md
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '26'
 
       - name: Install dependencies
         uses: egose/actions/npm-packages@main

--- a/pnpm-packages/README.md
+++ b/pnpm-packages/README.md
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '26'
 
       - run: corepack enable
 

--- a/yarn-packages/README.md
+++ b/yarn-packages/README.md
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '26'
 
       - run: corepack enable
 


### PR DESCRIPTION
## Summary

This PR updates pinned GitHub Action revisions across the repository, refreshes local development tool versions in `.tool-versions`, updates the package fixture examples and workflow tests to use Node 26, and improves the `asdf-tools` cache key to avoid collisions across runner architectures.

## Changes

### Workflow and action pinning
- Updated checkout and setup-related actions to current pinned revisions.
- Refreshed `actions/cache`, `actions/setup-node`, `actions/setup-python`, `softprops/action-gh-release`, `hmarr/debug-action`, and `rhysd/actionlint` references where used.
- Kept the existing workflow behavior unchanged while removing older action pins.

### Local tool versions
- Bumped local development tools in `.tool-versions`:
  - `nodejs` to `26.4.0`
  - `python` to `3.14.6`
  - `pnpm` to `11.10.0`
  - `act` to `0.2.89`

### Package fixture examples and CI workflows
- Updated the npm, pnpm, and yarn package fixture README examples to use `node-version: '26'`.
- Updated the corresponding GitHub workflow tests to run against Node 26 as well.
- This keeps the documented examples and CI coverage aligned with the refreshed runtime baseline.

### asdf tool caching
- Included `runner.arch` in the `asdf-tools` cache key so cached tool installs are separated by architecture as well as OS and tool versions.
- This reduces the risk of reusing incompatible caches on different runner hardware.

## Notes

- These updates are maintenance-oriented and should help keep CI and local tooling aligned with newer versions.
- No application code or workflow logic was changed beyond version refreshes, example updates, and cache-key hardening.