### PR TITLE
Bump asdf default version to v0.19.0

### DIFF
--- a/asdf-tools/action.yml
+++ b/asdf-tools/action.yml
@@ -4,7 +4,7 @@ description: Install asdf tools based on the .tool-versions file and additional 
 inputs:
   version:
     description: The version of asdf
-    default: v0.18.0
+    default: v0.19.0
     required: false
   plugins:
     description: List of additional plugins (e.g., <plugin>=<url>, comma-separated)


### PR DESCRIPTION
## Summary

Update the default `asdf` version used by the `asdf-tools` action from `v0.18.0` to `v0.19.0`.

## Changes

- Adjust the `version` input default in `asdf-tools/action.yml`
- Keep the action interface unchanged aside from the newer default

## Notes

This change ensures new runs of the action use the newer `asdf` release without requiring callers to override the version explicitly.