### PR TITLE
Add oc-login action and improve pre-commit bootstrap

### DIFF
--- a/.github/workflows/test-oc-login.yml
+++ b/.github/workflows/test-oc-login.yml
@@ -1,0 +1,97 @@
+name: Test action oc-login
+
+on:
+  pull_request:
+    paths:
+    - .github/workflows/test-oc-login.yml
+    - asdf-install/**
+    - oc-login/**
+    - tests/fixtures/oc-login/**
+  push:
+    branches:
+    - main
+    paths:
+    - .github/workflows/test-oc-login.yml
+    - asdf-install/**
+    - oc-login/**
+    - tests/fixtures/oc-login/**
+  workflow_dispatch:
+
+jobs:
+  oc-login-uses-existing-oc:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+    - name: Install fake oc binary
+      shell: bash
+      run: |
+        mkdir -p "$RUNNER_TEMP/bin"
+        install -m 0755 tests/fixtures/oc-login/oc "$RUNNER_TEMP/bin/oc"
+        echo "$RUNNER_TEMP/bin" >> "$GITHUB_PATH"
+
+    - name: Run oc-login action with username/password
+      uses: ./oc-login
+      env:
+        FAKE_OC_LOG: ${{ runner.temp }}/oc-login.log
+      with:
+        openshift_server_url: https://api.example.test:6443
+        openshift_token: ignored-token
+        openshift_username: demo-user
+        openshift_password: demo-password
+        insecure_skip_tls_verify: 'true'
+        certificate_authority_data: |
+          -----BEGIN CERTIFICATE-----
+          fake-ca
+          -----END CERTIFICATE-----
+        namespace: example-namespace
+
+    - name: Verify login arguments and kubeconfig export
+      shell: bash
+      env:
+        FAKE_OC_LOG: ${{ runner.temp }}/oc-login.log
+      run: |
+        test -n "${KUBECONFIG:-}"
+        test -f "$KUBECONFIG"
+        grep -q '^cmd=login$' "$FAKE_OC_LOG"
+        grep -q '^arg=--server=https://api.example.test:6443$' "$FAKE_OC_LOG"
+        grep -q '^arg=--username=demo-user$' "$FAKE_OC_LOG"
+        grep -q '^arg=--password=demo-password$' "$FAKE_OC_LOG"
+
+        if grep -q '^arg=--token=' "$FAKE_OC_LOG"; then
+          exit 1
+        fi
+
+        if grep -q '^arg=--insecure-skip-tls-verify=true$' "$FAKE_OC_LOG"; then
+          exit 1
+        fi
+
+        ca_arg="$(grep '^arg=--certificate-authority=' "$FAKE_OC_LOG")"
+        test -n "$ca_arg"
+        ca_file="${ca_arg#arg=--certificate-authority=}"
+        grep -q 'BEGIN CERTIFICATE' "$ca_file"
+        grep -q '^cmd=project$' "$FAKE_OC_LOG"
+        grep -q '^arg=example-namespace$' "$FAKE_OC_LOG"
+
+  oc-login-makes-oc-available:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+    - name: Run oc-login action against an unreachable cluster
+      id: oclogin
+      continue-on-error: true
+      uses: ./oc-login
+      with:
+        openshift_server_url: https://127.0.0.1:9
+        openshift_token: dummy-token
+        insecure_skip_tls_verify: 'true'
+        oc-version: latest
+
+    - name: Verify oc is available after the action
+      shell: bash
+      env:
+        OCLOGIN_OUTCOME: ${{ steps.oclogin.outcome }}
+      run: |
+        test "$OCLOGIN_OUTCOME" = "failure"
+        oc version --client || oc version

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository contains several reusable composite GitHub Actions.
 | [`asdf-tools`](./asdf-tools/README.md) | Installs `asdf` and tool versions from `.tool-versions`. |
 | [`docker-build-push`](./docker-build-push/README.md) | Builds and pushes a Docker image, with optional Trivy scanning. |
 | [`npm-packages`](./npm-packages/README.md) | Runs `npm install` across one or more package directories. |
+| [`oc-login`](./oc-login/README.md) | Ensures `oc` exists and logs into an OpenShift cluster. |
 | [`pnpm-packages`](./pnpm-packages/README.md) | Runs `pnpm install` across one or more package directories. |
 | [`pre-commit`](./pre-commit/README.md) | Runs `pre-commit` and can commit hook-generated changes. |
 | [`release-tag`](./release-tag/README.md) | Generates release candidate PRs from semantic versioning rules. |

--- a/oc-login/README.md
+++ b/oc-login/README.md
@@ -1,0 +1,71 @@
+# OpenShift oc login
+
+Ensures `oc` is available on the runner and logs into an OpenShift cluster.
+
+## What It Does
+
+- Reuses an existing `oc` installation when one is already on `PATH`.
+- Installs `asdf` with [`asdf-install`](../asdf-install/README.md) when `oc` is missing.
+- Installs `oc` with the [`asdf-oc`](https://github.com/sqtran/asdf-oc) plugin when needed.
+- Logs into the configured OpenShift cluster with either a token or username/password.
+- Writes a temporary `KUBECONFIG` file and exports it for later workflow steps.
+- Optionally switches the current project with `oc project` after login.
+
+## Usage
+
+### Login with a Token
+
+```yaml
+- name: Login to OpenShift
+  uses: egose/actions/oc-login@main
+  with:
+    openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
+    openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
+    insecure_skip_tls_verify: 'true'
+```
+
+### Login with Username and Password
+
+```yaml
+- name: Login to OpenShift with credentials
+  uses: egose/actions/oc-login@main
+  with:
+    openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
+    openshift_username: ${{ env.OPENSHIFT_USER }}
+    openshift_password: ${{ secrets.OPENSHIFT_PASSWORD }}
+    certificate_authority_data: ${{ secrets.CA_DATA }}
+    namespace: ${{ env.OPENSHIFT_NAMESPACE }}
+```
+
+### Pin Fallback Tool Versions
+
+```yaml
+- name: Login with pinned fallback tool versions
+  uses: egose/actions/oc-login@main
+  with:
+    openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
+    openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
+    asdf-version: v0.19.0
+    oc-version: latest
+```
+
+## Inputs
+
+| Name | Required | Default | Description |
+| --- | --- | --- | --- |
+| `openshift_server_url` | Yes | `""` | URL of the OpenShift cluster API server. |
+| `openshift_token` | No | `""` | Authentication token for `oc login`. |
+| `openshift_username` | No | `""` | Username for `oc login`. Overrides `openshift_token` when paired with `openshift_password`. |
+| `openshift_password` | No | `""` | Password for `oc login`. Must be set with `openshift_username`. |
+| `insecure_skip_tls_verify` | No | `"false"` | Skip TLS verification when `certificate_authority_data` is not provided. |
+| `certificate_authority_data` | No | `""` | PEM or base64-encoded PEM certificate authority data passed to `oc login`. |
+| `namespace` | No | `""` | Namespace to select with `oc project` after login. |
+| `asdf-version` | No | `v0.19.0` | `asdf` version to install when `oc` is missing. |
+| `oc-version` | No | `latest` | `oc` version to install with `asdf` when `oc` is missing. |
+
+## Notes
+
+- Either `openshift_token` or both `openshift_username` and `openshift_password` must be provided.
+- When both token and username/password are set, username/password takes precedence.
+- When `certificate_authority_data` is provided, it is used instead of `insecure_skip_tls_verify`.
+- Existing `oc` installations are reused as-is.

--- a/oc-login/action.yml
+++ b/oc-login/action.yml
@@ -1,0 +1,72 @@
+name: OpenShift oc login
+description: Ensure the oc CLI exists and log into an OpenShift cluster
+
+inputs:
+  openshift_server_url:
+    description: URL of the OpenShift cluster API server
+    required: true
+  openshift_token:
+    description: Authentication token for oc login
+    required: false
+  openshift_username:
+    description: Username for oc login; overrides token when paired with openshift_password
+    required: false
+  openshift_password:
+    description: Password for oc login; overrides token when paired with openshift_username
+    required: false
+  insecure_skip_tls_verify:
+    description: Skip TLS certificate verification when certificate_authority_data is not provided
+    required: false
+    default: 'false'
+  certificate_authority_data:
+    description: PEM or base64-encoded PEM certificate authority data
+    required: false
+  namespace:
+    description: Namespace to select after a successful login
+    required: false
+  asdf-version:
+    description: Version of asdf to install when oc is missing
+    required: false
+    default: v0.19.0
+  oc-version:
+    description: Version of oc to install with asdf when oc is missing
+    required: false
+    default: latest
+
+runs:
+  using: composite
+  steps:
+  - name: Check oc availability
+    id: oc
+    shell: bash
+    run: |
+      if command -v oc >/dev/null 2>&1; then
+        echo "oc_ready=true" >> "$GITHUB_OUTPUT"
+      else
+        echo "oc_ready=false" >> "$GITHUB_OUTPUT"
+      fi
+
+  - name: Install asdf
+    if: steps.oc.outputs.oc_ready != 'true'
+    uses: ./asdf-install
+    with:
+      version: ${{ inputs.asdf-version }}
+
+  - name: Ensure oc exists
+    if: steps.oc.outputs.oc_ready != 'true'
+    shell: bash
+    run: bash "${{ github.action_path }}/ensure-dependencies.sh"
+    env:
+      OCLOGIN_OC_VERSION: ${{ inputs.oc-version }}
+
+  - name: Log in to OpenShift
+    shell: bash
+    run: bash "${{ github.action_path }}/login.sh"
+    env:
+      OCLOGIN_SERVER_URL: ${{ inputs.openshift_server_url }}
+      OCLOGIN_TOKEN: ${{ inputs.openshift_token }}
+      OCLOGIN_USERNAME: ${{ inputs.openshift_username }}
+      OCLOGIN_PASSWORD: ${{ inputs.openshift_password }}
+      OCLOGIN_INSECURE_SKIP_TLS_VERIFY: ${{ inputs.insecure_skip_tls_verify }}
+      OCLOGIN_CERTIFICATE_AUTHORITY_DATA: ${{ inputs.certificate_authority_data }}
+      OCLOGIN_NAMESPACE: ${{ inputs.namespace }}

--- a/oc-login/ensure-dependencies.sh
+++ b/oc-login/ensure-dependencies.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if command -v oc >/dev/null 2>&1; then
+  echo "✅ oc already available"
+  exit 0
+fi
+
+export PATH="${RUNNER_TEMP}/asdf-bin:${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
+
+if ! command -v asdf >/dev/null 2>&1; then
+  echo "❌ asdf is unavailable after bootstrap"
+  exit 1
+fi
+
+echo "➡️ Installing oc ${OCLOGIN_OC_VERSION}..."
+asdf plugin add oc https://github.com/sqtran/asdf-oc.git || true
+asdf install oc "${OCLOGIN_OC_VERSION}"
+
+oc_root=""
+if oc_root="$(asdf where oc "${OCLOGIN_OC_VERSION}" 2>/dev/null)"; then
+  :
+else
+  installed_version="$(asdf list oc | awk 'NF { version=$1 } END { gsub(/^[* ]+/, "", version); print version }')"
+  if [ -z "$installed_version" ]; then
+    echo "❌ Unable to determine installed oc version"
+    exit 1
+  fi
+
+  oc_root="$(asdf where oc "$installed_version")"
+fi
+
+echo "$oc_root/bin" >> "$GITHUB_PATH"
+export PATH="$oc_root/bin:$PATH"
+
+if ! command -v oc >/dev/null 2>&1; then
+  echo "❌ oc is unavailable after dependency bootstrap"
+  exit 1
+fi
+
+oc version --client || oc version

--- a/oc-login/login.sh
+++ b/oc-login/login.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+is_truthy() {
+  case "${1:-}" in
+    true|TRUE|True|1|yes|YES|on|ON)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+decode_base64() {
+  if printf 'Zm9v' | base64 --decode >/dev/null 2>&1; then
+    base64 --decode
+    return
+  fi
+
+  if printf 'Zm9v' | base64 -d >/dev/null 2>&1; then
+    base64 -d
+    return
+  fi
+
+  base64 -D
+}
+
+server_url="${OCLOGIN_SERVER_URL:-}"
+token="${OCLOGIN_TOKEN:-}"
+username="${OCLOGIN_USERNAME:-}"
+password="${OCLOGIN_PASSWORD:-}"
+ca_data="${OCLOGIN_CERTIFICATE_AUTHORITY_DATA:-}"
+namespace="${OCLOGIN_NAMESPACE:-}"
+insecure_skip_tls_verify="${OCLOGIN_INSECURE_SKIP_TLS_VERIFY:-false}"
+
+if [ -z "$server_url" ]; then
+  echo "❌ openshift_server_url is required"
+  exit 1
+fi
+
+if [ -n "$username" ] || [ -n "$password" ]; then
+  if [ -z "$username" ] || [ -z "$password" ]; then
+    echo "❌ openshift_username and openshift_password must both be provided"
+    exit 1
+  fi
+
+  auth_mode="username_password"
+elif [ -n "$token" ]; then
+  auth_mode="token"
+else
+  echo "❌ Provide openshift_token or both openshift_username and openshift_password"
+  exit 1
+fi
+
+kubeconfig_path="${RUNNER_TEMP}/oc-login-kubeconfig"
+mkdir -p "$(dirname "$kubeconfig_path")"
+: > "$kubeconfig_path"
+chmod 600 "$kubeconfig_path"
+echo "KUBECONFIG=$kubeconfig_path" >> "$GITHUB_ENV"
+export KUBECONFIG="$kubeconfig_path"
+
+login_args=(login "--server=${server_url}")
+
+if [ "$auth_mode" = "username_password" ]; then
+  login_args+=("--username=${username}" "--password=${password}")
+else
+  login_args+=("--token=${token}")
+fi
+
+if [ -n "$ca_data" ]; then
+  ca_file="${RUNNER_TEMP}/oc-login-ca.crt"
+
+  case "$ca_data" in
+    *"-----BEGIN "*)
+      printf '%s\n' "$ca_data" > "$ca_file"
+      ;;
+    *)
+      if ! printf '%s' "$ca_data" | decode_base64 > "$ca_file" 2>/dev/null; then
+        echo "❌ certificate_authority_data must be PEM data or base64-encoded PEM"
+        exit 1
+      fi
+      ;;
+  esac
+
+  login_args+=("--certificate-authority=${ca_file}")
+elif is_truthy "$insecure_skip_tls_verify"; then
+  login_args+=("--insecure-skip-tls-verify=true")
+fi
+
+oc "${login_args[@]}"
+
+if [ -n "$namespace" ]; then
+  oc project "$namespace"
+fi

--- a/pre-commit/README.md
+++ b/pre-commit/README.md
@@ -64,6 +64,7 @@ jobs:
 - name: Run pre-commit with pinned fallback tool versions
   uses: egose/actions/pre-commit@main
   with:
+    asdf-version: 'v0.19.0'
     python-version: '3.14.6'
     pre-commit-version: '4.6.0'
 ```
@@ -73,6 +74,7 @@ jobs:
 | Name | Required | Default | Description |
 | --- | --- | --- | --- |
 | `config` | No | `.pre-commit-config.yaml` | Path to the pre-commit configuration file. |
+| `asdf-version` | No | `v0.19.0` | `asdf` version to install when `python3` is missing. |
 | `python-version` | No | `3.14.6` | Python version to install with `asdf` when `python3` is missing. |
 | `pre-commit-version` | No | `4.6.0` | `pre-commit` version to install when `pre-commit` is missing. |
 | `commit-on-pr` | No | `"true"` | Commit and push hook changes when the workflow runs on `pull_request`. |
@@ -80,7 +82,7 @@ jobs:
 
 ## Notes
 
-- If `python3` is missing, the action installs `asdf` and Python automatically before running hooks.
+- If `python3` is missing, the action installs `asdf` first and then installs Python automatically before running hooks.
 - If `pre-commit` is missing, the action installs the configured version automatically with `pip --user`.
 - Existing `python3` and `pre-commit` installations are reused as-is.
 - Automatic push-back requires repository write permissions and a checkout that can push to the current branch.

--- a/pre-commit/action.yml
+++ b/pre-commit/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: Path to pre-commit configuration file
     required: false
     default: .pre-commit-config.yaml
+  asdf-version:
+    description: asdf version to install when python3 is missing
+    required: false
+    default: v0.19.0
   python-version:
     description: Python version to install with asdf when python3 is missing
     required: false
@@ -34,11 +38,39 @@ runs:
       restore-keys: |
         pre-commit-
 
+  - name: Check python3 and pre-commit availability
+    id: dependencies
+    shell: bash
+    run: |
+      if command -v python3 >/dev/null 2>&1; then
+        echo "python_ready=true" >> "$GITHUB_OUTPUT"
+      else
+        echo "python_ready=false" >> "$GITHUB_OUTPUT"
+      fi
+
+      if command -v pre-commit >/dev/null 2>&1; then
+        echo "precommit_ready=true" >> "$GITHUB_OUTPUT"
+      else
+        echo "precommit_ready=false" >> "$GITHUB_OUTPUT"
+      fi
+
+      if command -v python3 >/dev/null 2>&1 && command -v pre-commit >/dev/null 2>&1; then
+        echo "dependencies_ready=true" >> "$GITHUB_OUTPUT"
+      else
+        echo "dependencies_ready=false" >> "$GITHUB_OUTPUT"
+      fi
+
+  - name: Install asdf
+    if: steps.dependencies.outputs.python_ready != 'true'
+    uses: ./asdf-install
+    with:
+      version: ${{ inputs.asdf-version }}
+
   - name: Ensure python3 and pre-commit exist
+    if: steps.dependencies.outputs.dependencies_ready != 'true'
     shell: bash
     run: bash "${{ github.action_path }}/ensure-dependencies.sh"
     env:
-      PRECOMMIT_ACTION_PATH: ${{ github.action_path }}
       PRECOMMIT_PYTHON_VERSION: ${{ inputs.python-version }}
       PRECOMMIT_VERSION: ${{ inputs.pre-commit-version }}
 

--- a/pre-commit/ensure-dependencies.sh
+++ b/pre-commit/ensure-dependencies.sh
@@ -19,9 +19,14 @@ if [ "$python_ready" = "true" ] && [ "$precommit_ready" = "true" ]; then
 fi
 
 if [ "$python_ready" != "true" ]; then
-  echo "➡️ Installing asdf and Python ${PRECOMMIT_PYTHON_VERSION}..."
-  bash "${PRECOMMIT_ACTION_PATH}/../asdf-install/install.sh"
+  echo "➡️ Installing Python ${PRECOMMIT_PYTHON_VERSION} with asdf..."
   export PATH="${RUNNER_TEMP}/asdf-bin:${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
+
+  if ! command -v asdf >/dev/null 2>&1; then
+    echo "❌ asdf is unavailable after bootstrap"
+    exit 1
+  fi
+
   asdf plugin add python https://github.com/danhper/asdf-python.git || true
   asdf install python "${PRECOMMIT_PYTHON_VERSION}"
 

--- a/precommit/action.yml
+++ b/precommit/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: Path to pre-commit configuration file
     required: false
     default: .pre-commit-config.yaml
+  asdf-version:
+    description: asdf version to install when python3 is missing
+    required: false
+    default: v0.19.0
   python-version:
     description: Python version to install with asdf when python3 is missing
     required: false
@@ -30,6 +34,7 @@ runs:
     uses: ./pre-commit
     with:
       config: ${{ inputs.config }}
+      asdf-version: ${{ inputs.asdf-version }}
       python-version: ${{ inputs.python-version }}
       pre-commit-version: ${{ inputs.pre-commit-version }}
       commit-on-pr: ${{ inputs.commit-on-pr }}

--- a/tests/fixtures/oc-login/oc
+++ b/tests/fixtures/oc-login/oc
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+log_file="${FAKE_OC_LOG:?FAKE_OC_LOG is required}"
+command_name="${1:-}"
+
+if [ -z "$command_name" ]; then
+  echo "missing command" >&2
+  exit 1
+fi
+
+printf 'cmd=%s\n' "$command_name" >> "$log_file"
+shift
+
+for arg in "$@"; do
+  printf 'arg=%s\n' "$arg" >> "$log_file"
+done
+
+case "$command_name" in
+  version)
+    printf 'Client Version: fake\n'
+    ;;
+  login|project)
+    ;;
+  *)
+    printf 'unexpected=%s\n' "$command_name" >> "$log_file"
+    ;;
+esac


### PR DESCRIPTION
## Summary

This change set introduces a new `oc-login` composite action for logging into OpenShift clusters and reworks `pre-commit` so it can bootstrap `asdf` explicitly when `python3` is missing.

## What changed

### New `oc-login` action
- Adds a new composite action that ensures `oc` is available before logging in.
- Supports login via either token or username/password.
- Handles optional namespace selection with `oc project`.
- Supports certificate authority data or insecure TLS verification.
- Exports a temporary `KUBECONFIG` for later workflow steps.
- Installs `asdf` and `oc` on demand when `oc` is not already available.

### `pre-commit` bootstrap improvements
- Adds a configurable `asdf-version` input.
- Installs `asdf` separately when `python3` is missing, then installs Python and `pre-commit`.
- Updates the implementation to check dependency availability up front and avoid redundant bootstrap work.
- Refreshes the documentation to describe the new behavior and input.

### Verification
- Adds a workflow to exercise the new `oc-login` action in CI.
- Includes a fake `oc` fixture for testing login behavior and path export.

## Notes

- Existing `oc`, `python3`, and `pre-commit` installations are still reused when present.
- The new `asdf-version` inputs allow pinning the fallback toolchain used during bootstrap.