### PR TITLE
Install asdf during dependency checks

### DIFF
--- a/oc-login/action.yml
+++ b/oc-login/action.yml
@@ -46,17 +46,13 @@ runs:
         echo "oc_ready=false" >> "$GITHUB_OUTPUT"
       fi
 
-  - name: Install asdf
-    if: steps.oc.outputs.oc_ready != 'true'
-    uses: ./asdf-install
-    with:
-      version: ${{ inputs.asdf-version }}
-
   - name: Ensure oc exists
     if: steps.oc.outputs.oc_ready != 'true'
     shell: bash
     run: bash "${{ github.action_path }}/ensure-dependencies.sh"
     env:
+      OCLOGIN_ACTION_PATH: ${{ github.action_path }}
+      OCLOGIN_ASDF_VERSION: ${{ inputs.asdf-version }}
       OCLOGIN_OC_VERSION: ${{ inputs.oc-version }}
 
   - name: Log in to OpenShift

--- a/oc-login/ensure-dependencies.sh
+++ b/oc-login/ensure-dependencies.sh
@@ -7,6 +7,8 @@ if command -v oc >/dev/null 2>&1; then
   exit 0
 fi
 
+echo "➡️ Installing asdf ${OCLOGIN_ASDF_VERSION}..."
+ASDF_VERSION="${OCLOGIN_ASDF_VERSION}" bash "${OCLOGIN_ACTION_PATH}/../asdf-install/install.sh"
 export PATH="${RUNNER_TEMP}/asdf-bin:${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 
 if ! command -v asdf >/dev/null 2>&1; then

--- a/pre-commit/action.yml
+++ b/pre-commit/action.yml
@@ -60,17 +60,13 @@ runs:
         echo "dependencies_ready=false" >> "$GITHUB_OUTPUT"
       fi
 
-  - name: Install asdf
-    if: steps.dependencies.outputs.python_ready != 'true'
-    uses: ./asdf-install
-    with:
-      version: ${{ inputs.asdf-version }}
-
   - name: Ensure python3 and pre-commit exist
     if: steps.dependencies.outputs.dependencies_ready != 'true'
     shell: bash
     run: bash "${{ github.action_path }}/ensure-dependencies.sh"
     env:
+      PRECOMMIT_ACTION_PATH: ${{ github.action_path }}
+      PRECOMMIT_ASDF_VERSION: ${{ inputs.asdf-version }}
       PRECOMMIT_PYTHON_VERSION: ${{ inputs.python-version }}
       PRECOMMIT_VERSION: ${{ inputs.pre-commit-version }}
 

--- a/pre-commit/ensure-dependencies.sh
+++ b/pre-commit/ensure-dependencies.sh
@@ -19,7 +19,8 @@ if [ "$python_ready" = "true" ] && [ "$precommit_ready" = "true" ]; then
 fi
 
 if [ "$python_ready" != "true" ]; then
-  echo "➡️ Installing Python ${PRECOMMIT_PYTHON_VERSION} with asdf..."
+  echo "➡️ Installing asdf ${PRECOMMIT_ASDF_VERSION} and Python ${PRECOMMIT_PYTHON_VERSION}..."
+  ASDF_VERSION="${PRECOMMIT_ASDF_VERSION}" bash "${PRECOMMIT_ACTION_PATH}/../asdf-install/install.sh"
   export PATH="${RUNNER_TEMP}/asdf-bin:${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
 
   if ! command -v asdf >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

This change moves `asdf` installation into the dependency-check scripts used by the `oc-login` and `pre-commit` actions.

## What changed

- Removed the separate `Install asdf` step from both action definitions.
- Passed the action path and requested `asdf` version into the dependency scripts.
- Updated the dependency scripts to invoke `asdf-install` directly when `asdf` is needed.
- Kept the existing readiness checks intact so `asdf` is only installed when the required tools are missing.

## Result

- `oc-login` now installs `asdf` as part of ensuring `oc` is available.
- `pre-commit` now installs `asdf` as part of ensuring Python and `pre-commit` are available.
- The actions are simpler, with installation logic centralized in the helper scripts.

## Files changed

- `oc-login/action.yml`
- `oc-login/ensure-dependencies.sh`
- `pre-commit/action.yml`
- `pre-commit/ensure-dependencies.sh`