### PR TITLE
Add Docker metadata annotations and refresh CI versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,6 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
     - name: Release
-      uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b
+      uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228
       with:
         token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-asdf-tools.yml
+++ b/.github/workflows/test-asdf-tools.yml
@@ -32,7 +32,6 @@ jobs:
           runner: macos-14
     runs-on: ${{ matrix.platform.runner }}
     steps:
-    - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
     - name: Install asdf binary
@@ -58,7 +57,6 @@ jobs:
           runner: macos-14
     runs-on: ${{ matrix.platform.runner }}
     steps:
-    - uses: hmarr/debug-action@cd1afbd7852b7ad7b1b7a9a1b03efebd3b0a1820
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
     - name: Install asdf tools in another directory

--- a/.github/workflows/test-npm-packages.yml
+++ b/.github/workflows/test-npm-packages.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
-    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
       with:
         node-version: '26'
 

--- a/.github/workflows/test-pnpm-packages.yml
+++ b/.github/workflows/test-pnpm-packages.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
-    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
       with:
         node-version: '26'
 

--- a/.github/workflows/test-yarn-packages.yml
+++ b/.github/workflows/test-yarn-packages.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
 
-    - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
       with:
         node-version: '26'
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
 nodejs 26.5.0
 python 3.14.6
-pnpm 11.11.0
+pnpm 11.15.0
 act 0.2.89
 actionlint 1.7.12
 shellcheck 0.11.0

--- a/docker-build-push/action.yml
+++ b/docker-build-push/action.yml
@@ -20,6 +20,9 @@ inputs:
   metadata-labels:
     description: List of labels as key-value pair attributes
     required: false
+  metadata-annotations:
+    description: List of annotations as key-value pair attributes
+    required: false
   docker-context:
     description: Docker build's context
     required: false
@@ -85,6 +88,7 @@ runs:
       images: ${{ inputs.registry-url }}/${{ inputs.image-name }}
       tags: ${{ inputs.metadata-tags }}
       labels: ${{ inputs.metadata-labels }}
+      annotations: ${{ inputs.metadata-annotations }}
 
   - name: Set up Docker Buildx
     # See https://github.com/docker/setup-buildx-action/commits/master/
@@ -119,6 +123,7 @@ runs:
         BUILD_TIMESTAMP=${{ env.BUILD_TIMESTAMP }}
         ${{ inputs.docker-args }}
       labels: ${{ steps.meta.outputs.labels }}
+      annotations: ${{ steps.meta.outputs.annotations }}
       outputs: ${{ inputs.docker-outputs }}
       cache-from: type=local,src=${{ env.DOCKER_LAYERS_PATH }}
       cache-to: type=local,dest=${{ env.DOCKER_LAYERS_PATH }}-new


### PR DESCRIPTION
## Summary

This PR updates the Docker build/push composite action to support metadata annotations, and refreshes several pinned workflow/tool versions used by CI and release automation.

## Changes

### Feature: Docker metadata annotations
- Added a new optional `metadata-annotations` input to `docker-build-push/action.yml`
- Passed annotations through to `docker/metadata-action`
- Forwarded generated annotations into the final `docker/build-push-action` step

### Maintenance: dependency and workflow pin updates
- Updated the GitHub release workflow to a newer `softprops/action-gh-release` revision
- Updated Node setup action pins in the npm, pnpm, and yarn workflow tests
- Removed `hmarr/debug-action` from the asdf workflow tests
- Bumped the local `pnpm` version in `.tool-versions`

## Notes

- The Docker action change is additive and should remain backward compatible.
- The workflow updates keep CI and release automation aligned with current pinned action versions.