### PR TITLE
Add shared metadata inputs for Docker metadata action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,12 @@ inputs:
   metadata-labels:
     description: List of labels as key-value pair attributes
     required: false
+  metadata-annotations:
+    description: List of annotations as key-value pair attributes
+    required: false
+  metadata-labels-annotations:
+    description: List of key-value pair attributes applied to both labels and annotations
+    required: false
   docker-context:
     description: Docker build's context
     required: false
@@ -79,6 +85,8 @@ runs:
       image-name: ${{ inputs.image-name }}
       metadata-tags: ${{ inputs.metadata-tags }}
       metadata-labels: ${{ inputs.metadata-labels }}
+      metadata-annotations: ${{ inputs.metadata-annotations }}
+      metadata-labels-annotations: ${{ inputs.metadata-labels-annotations }}
       docker-context: ${{ inputs.docker-context }}
       docker-file: ${{ inputs.docker-file }}
       docker-args: ${{ inputs.docker-args }}

--- a/docker-build-push/README.md
+++ b/docker-build-push/README.md
@@ -5,7 +5,7 @@ Builds a Docker image, pushes it to a registry, and exposes the generated Docker
 ## What It Does
 
 - Logs in to the target container registry.
-- Generates tags and labels with `docker/metadata-action`.
+- Generates tags, labels, and annotations with `docker/metadata-action`.
 - Builds and pushes the image with `docker/build-push-action`.
 - Reuses a local Buildx layer cache between runs.
 - Optionally runs Trivy and uploads SARIF results to the GitHub Security tab.
@@ -62,6 +62,25 @@ jobs:
     trivy: 'true'
 ```
 
+### Share Metadata Between Labels And Annotations
+
+```yaml
+- name: Build and push image
+  uses: egose/actions/docker-build-push@main
+  with:
+    registry-url: ghcr.io
+    registry-username: ${{ github.actor }}
+    registry-password: ${{ secrets.GITHUB_TOKEN }}
+    image-name: egose/myapp
+    metadata-tags: |
+      type=sha
+    metadata-labels-annotations: |
+      org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+      org.opencontainers.image.revision=${{ github.sha }}
+    metadata-labels: |
+      org.opencontainers.image.title=myapp
+```
+
 ## Inputs
 
 | Name | Required | Default | Description |
@@ -72,6 +91,8 @@ jobs:
 | `image-name` | Yes |  | Image name without the registry prefix. |
 | `metadata-tags` | Yes |  | Newline-separated tag rules in `docker/metadata-action` format. |
 | `metadata-labels` | No |  | Newline-separated label rules in `docker/metadata-action` format. |
+| `metadata-annotations` | No |  | Newline-separated annotation rules in `docker/metadata-action` format. |
+| `metadata-labels-annotations` | No |  | Newline-separated rules applied to both labels and annotations. If the same key appears in both this input and a specific metadata input, the specific input wins. |
 | `docker-context` | No |  | Build context passed to `docker/build-push-action`. |
 | `docker-file` | No |  | Path to the Dockerfile. |
 | `docker-args` | No |  | Additional build args. `BUILD_TIMESTAMP` is always injected automatically. |
@@ -96,4 +117,5 @@ jobs:
 
 - This action always pushes the built image. There is no build-only mode.
 - The image reference is constructed as `${{ inputs.registry-url }}/${{ inputs.image-name }}`.
+- `metadata-labels-annotations` is appended to both `labels` and `annotations` for `docker/metadata-action`, then the specific input is appended after it so `metadata-labels` and `metadata-annotations` override shared keys.
 - The Trivy steps require `security-events: write` permission if you want SARIF uploaded to GitHub code scanning.

--- a/docker-build-push/action.yml
+++ b/docker-build-push/action.yml
@@ -23,6 +23,9 @@ inputs:
   metadata-annotations:
     description: List of annotations as key-value pair attributes
     required: false
+  metadata-labels-annotations:
+    description: List of key-value pair attributes applied to both labels and annotations
+    required: false
   docker-context:
     description: Docker build's context
     required: false
@@ -87,8 +90,12 @@ runs:
     with:
       images: ${{ inputs.registry-url }}/${{ inputs.image-name }}
       tags: ${{ inputs.metadata-tags }}
-      labels: ${{ inputs.metadata-labels }}
-      annotations: ${{ inputs.metadata-annotations }}
+      labels: |
+        ${{ inputs.metadata-labels-annotations }}
+        ${{ inputs.metadata-labels }}
+      annotations: |
+        ${{ inputs.metadata-labels-annotations }}
+        ${{ inputs.metadata-annotations }}
 
   - name: Set up Docker Buildx
     # See https://github.com/docker/setup-buildx-action/commits/master/


### PR DESCRIPTION
## Summary

This change adds support for sharing metadata rules between Docker labels and annotations in the Docker build/push action.

## What changed

- Added a new `metadata-labels-annotations` input to both action entrypoints.
- Added a new `metadata-annotations` input at the top-level action entrypoint.
- Updated the Docker metadata wiring so shared rules are applied to both labels and annotations, with specific inputs overriding shared keys when duplicated.
- Documented the new inputs and added an example showing how to reuse metadata between labels and annotations.

## Notes

- `metadata-labels-annotations` is appended to both labels and annotations.
- `metadata-labels` and `metadata-annotations` are appended after the shared input so they take precedence for overlapping keys.
- Existing behavior remains unchanged for users who do not provide the new inputs.