### PR TITLE
Bump default asdf version to v0.20.0

### DIFF
--- a/.github/workflows/test-asdf-tools.yml
+++ b/.github/workflows/test-asdf-tools.yml
@@ -39,7 +39,7 @@ jobs:
 
     - name: Check asdf version
       run: |
-        asdf --version | grep -q "v0.19.0"
+        asdf --version | grep -q "v0.20.0"
       shell: bash
 
   asdf-tools-test:

--- a/asdf-install/README.md
+++ b/asdf-install/README.md
@@ -31,17 +31,17 @@ jobs:
 ### Pin a Specific Version
 
 ```yaml
-- name: Install asdf v0.19.0
+- name: Install asdf v0.20.0
   uses: egose/actions/asdf-install@main
   with:
-    version: v0.19.0
+    version: v0.20.0
 ```
 
 ## Inputs
 
 | Name | Required | Default | Description |
 | --- | --- | --- | --- |
-| `version` | No | `v0.19.0` | Version of the `asdf` binary to install. |
+| `version` | No | `v0.20.0` | Version of the `asdf` binary to install. |
 
 ## Notes
 

--- a/asdf-install/action.yml
+++ b/asdf-install/action.yml
@@ -4,7 +4,7 @@ description: Install the asdf CLI on Linux and macOS runners
 inputs:
   version:
     description: The version of asdf
-    default: v0.19.0
+    default: v0.20.0
     required: false
 
 runs:

--- a/asdf-install/install.sh
+++ b/asdf-install/install.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-ASDF_VERSION="${ASDF_VERSION:-v0.19.0}"
+ASDF_VERSION="${ASDF_VERSION:-v0.20.0}"
 install_dir="${RUNNER_TEMP}/asdf-bin"
 shims_dir="${ASDF_DATA_DIR:-$HOME/.asdf}/shims"
 

--- a/asdf-tools/README.md
+++ b/asdf-tools/README.md
@@ -53,7 +53,7 @@ jobs:
 
 | Name | Required | Default | Description |
 | --- | --- | --- | --- |
-| `version` | No | `v0.19.0` | Version of the `asdf` binary to install. |
+| `version` | No | `v0.20.0` | Version of the `asdf` binary to install. |
 | `plugins` | No | `""` | Newline-separated list of extra plugins in `<plugin>=<url>` format. |
 | `context` | No | `.` | Directory that contains the `.tool-versions` file. |
 

--- a/asdf-tools/action.yml
+++ b/asdf-tools/action.yml
@@ -4,7 +4,7 @@ description: Install asdf tools based on the .tool-versions file and additional 
 inputs:
   version:
     description: The version of asdf
-    default: v0.19.0
+    default: v0.20.0
     required: false
   plugins:
     description: List of additional plugins (e.g., <plugin>=<url>, comma-separated)
@@ -28,7 +28,10 @@ runs:
     uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
     with:
       path: ~/.asdf
-      key: ${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}-${{ hashFiles('**/.tool-versions') }}
+      key: asdf-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}-${{ hashFiles('**/.tool-versions') }}
+      restore-keys: |
+        asdf-${{ runner.os }}-${{ runner.arch }}-${{ inputs.version }}-
+        asdf-${{ runner.os }}-${{ runner.arch }}-
 
   - name: Install asdf tools
     run: bash "${{ github.action_path }}/install.sh"

--- a/oc-login/README.md
+++ b/oc-login/README.md
@@ -45,7 +45,7 @@ Ensures `oc` is available on the runner and logs into an OpenShift cluster.
   with:
     openshift_server_url: ${{ secrets.OPENSHIFT_SERVER }}
     openshift_token: ${{ secrets.OPENSHIFT_TOKEN }}
-    asdf-version: v0.19.0
+    asdf-version: v0.20.0
     oc-version: latest
 ```
 
@@ -60,7 +60,7 @@ Ensures `oc` is available on the runner and logs into an OpenShift cluster.
 | `insecure_skip_tls_verify` | No | `"false"` | Skip TLS verification when `certificate_authority_data` is not provided. |
 | `certificate_authority_data` | No | `""` | PEM or base64-encoded PEM certificate authority data passed to `oc login`. |
 | `namespace` | No | `""` | Namespace to select with `oc project` after login. |
-| `asdf-version` | No | `v0.19.0` | `asdf` version to install when `oc` is missing. |
+| `asdf-version` | No | `v0.20.0` | `asdf` version to install when `oc` is missing. |
 | `oc-version` | No | `latest` | `oc` version to install with `asdf` when `oc` is missing. |
 
 ## Notes

--- a/oc-login/action.yml
+++ b/oc-login/action.yml
@@ -27,7 +27,7 @@ inputs:
   asdf-version:
     description: Version of asdf to install when oc is missing
     required: false
-    default: v0.19.0
+    default: v0.20.0
   oc-version:
     description: Version of oc to install with asdf when oc is missing
     required: false

--- a/pre-commit/README.md
+++ b/pre-commit/README.md
@@ -64,7 +64,7 @@ jobs:
 - name: Run pre-commit with pinned fallback tool versions
   uses: egose/actions/pre-commit@main
   with:
-    asdf-version: 'v0.19.0'
+    asdf-version: 'v0.20.0'
     python-version: '3.14.6'
     pre-commit-version: '4.6.0'
 ```
@@ -74,7 +74,7 @@ jobs:
 | Name | Required | Default | Description |
 | --- | --- | --- | --- |
 | `config` | No | `.pre-commit-config.yaml` | Path to the pre-commit configuration file. |
-| `asdf-version` | No | `v0.19.0` | `asdf` version to install when `python3` is missing. |
+| `asdf-version` | No | `v0.20.0` | `asdf` version to install when `python3` is missing. |
 | `python-version` | No | `3.14.6` | Python version to install with `asdf` when `python3` is missing. |
 | `pre-commit-version` | No | `4.6.0` | `pre-commit` version to install when `pre-commit` is missing. |
 | `commit-on-pr` | No | `"true"` | Commit and push hook changes when the workflow runs on `pull_request`. |

--- a/pre-commit/action.yml
+++ b/pre-commit/action.yml
@@ -9,7 +9,7 @@ inputs:
   asdf-version:
     description: asdf version to install when python3 is missing
     required: false
-    default: v0.19.0
+    default: v0.20.0
   python-version:
     description: Python version to install with asdf when python3 is missing
     required: false

--- a/precommit/action.yml
+++ b/precommit/action.yml
@@ -9,7 +9,7 @@ inputs:
   asdf-version:
     description: asdf version to install when python3 is missing
     required: false
-    default: v0.19.0
+    default: v0.20.0
   python-version:
     description: Python version to install with asdf when python3 is missing
     required: false


### PR DESCRIPTION
## Summary

Update the repository’s default `asdf` version from `v0.19.0` to `v0.20.0` across the actions, documentation, and workflow validation.

## Changes

- Updated the default `asdf` version in all action inputs and install scripts that bootstrap `asdf`.
- Refreshed README examples and input tables to reflect the new default version.
- Updated the asdf tools cache key format to use a stable `asdf-...` prefix and added restore keys for broader cache reuse.
- Adjusted the workflow test to verify `asdf v0.20.0` is installed.

## Impact

These changes keep the repository aligned on the newer default `asdf` release while improving cache fallback behavior for `asdf-tools`.