### PR TITLE
Handle pnpm workspace roots during package installs

### DIFF
--- a/pnpm-packages/README.md
+++ b/pnpm-packages/README.md
@@ -80,5 +80,5 @@ jobs:
 - The cache key is based on `hashFiles('**/pnpm-lock.yaml')`, so any lockfile change refreshes the cache.
 - `frozen: 'true'` requires matching `pnpm-lock.yaml` files to already exist for each target directory.
 - `ignore-scripts: 'true'` applies to both normal installs and frozen installs.
-- Installs run with `--ignore-workspace`, so each target directory is installed against its own `package.json`/`pnpm-lock.yaml`. This prevents pnpm from walking up to a parent `pnpm-workspace.yaml` and writing the lockfile (or installing root dependencies) at that workspace root instead of the target directory.
+- Installs in a target directory that is itself a pnpm workspace root (i.e. it contains a `pnpm-workspace.yaml`) run as a normal workspace install so the full package set is materialized. Targets that are not workspace roots run with `--ignore-workspace` so each target directory is installed against its own `package.json`/`pnpm-lock.yaml` and pnpm does not walk up to a parent `pnpm-workspace.yaml` to write the lockfile (or install root dependencies) there.
 - This action has no outputs.

--- a/scripts/install-packages.sh
+++ b/scripts/install-packages.sh
@@ -16,18 +16,24 @@ install_target() {
       fi
       ;;
     pnpm)
-      # Always pass --ignore-workspace so installs run against the target
-      # directory's own package.json/lockfile, even when a parent directory
-      # contains a pnpm-workspace.yaml. Without this, pnpm walks up to the
-      # nearest workspace root and installs/writes the lockfile there.
+      # Pass --ignore-workspace only when the target directory is not itself a
+      # pnpm workspace root. This protects standalone projects nested under a
+      # parent pnpm-workspace.yaml (so pnpm doesn't walk up and mutate the
+      # parent's lockfile), while letting genuine workspace roots install their
+      # full package set normally.
+      workspace_flags=()
+      if [ ! -f 'pnpm-workspace.yaml' ]; then
+        workspace_flags+=(--ignore-workspace)
+      fi
+
       if [ "${PACKAGE_FROZEN}" = 'true' ] && [ "${PACKAGE_IGNORE_SCRIPTS}" = 'true' ]; then
-        pnpm install --ignore-workspace --frozen-lockfile --ignore-scripts
+        pnpm install "${workspace_flags[@]}" --frozen-lockfile --ignore-scripts
       elif [ "${PACKAGE_FROZEN}" = 'true' ]; then
-        pnpm install --ignore-workspace --frozen-lockfile
+        pnpm install "${workspace_flags[@]}" --frozen-lockfile
       elif [ "${PACKAGE_IGNORE_SCRIPTS}" = 'true' ]; then
-        pnpm install --ignore-workspace --ignore-scripts
+        pnpm install "${workspace_flags[@]}" --ignore-scripts
       else
-        pnpm install --ignore-workspace
+        pnpm install "${workspace_flags[@]}"
       fi
       ;;
     yarn)

--- a/tests/test-install-packages.sh
+++ b/tests/test-install-packages.sh
@@ -14,6 +14,9 @@ cleanup() {
 trap cleanup EXIT
 
 mkdir -p "$bin_dir" "${workspace}/apps/app one" "${workspace}/apps/app two"
+# A target that is itself a pnpm workspace root (has pnpm-workspace.yaml) must
+# NOT receive --ignore-workspace; this is the monorepo case.
+mkdir -p "${workspace}/mono"
 
 for manager in npm pnpm yarn; do
   cat > "${bin_dir}/${manager}" <<EOF
@@ -62,6 +65,36 @@ run_case() {
   fi
 }
 
+run_workspace_case() {
+  local manager="$1"
+  local frozen="$2"
+  local ignore_scripts="$3"
+  local expected="$4"
+
+  : > "$log_file"
+  touch "${workspace}/mono/pnpm-workspace.yaml"
+  PATH="${bin_dir}:$PATH" \
+  PACKAGE_MANAGER="$manager" \
+  PACKAGE_FROZEN="$frozen" \
+  PACKAGE_IGNORE_SCRIPTS="$ignore_scripts" \
+  PACKAGE_PATHS='mono' \
+  bash "${repo_root}/scripts/install-packages.sh"
+
+  mapfile -t lines < "$log_file"
+  if [ "${#lines[@]}" -ne 1 ]; then
+    echo "expected one install invocation for ${manager} workspace root, got ${#lines[@]}"
+    rm -f "${workspace}/mono/pnpm-workspace.yaml"
+    exit 1
+  fi
+  rm -f "${workspace}/mono/pnpm-workspace.yaml"
+
+  if [ "${lines[0]}" != "${manager}|${workspace}/mono::${expected}" ]; then
+    echo "unexpected invocation for ${manager} workspace root: ${lines[0]}"
+    echo "expected: ${manager}|${workspace}/mono::${expected}"
+    exit 1
+  fi
+}
+
 cd "$workspace"
 
 run_case npm true true 'ci --ignore-scripts' 'ci --ignore-scripts'
@@ -70,5 +103,10 @@ run_case pnpm true false 'install --ignore-workspace --frozen-lockfile' 'install
 run_case pnpm false true 'install --ignore-workspace --ignore-scripts' 'install --ignore-workspace --ignore-scripts'
 run_case pnpm true true 'install --ignore-workspace --frozen-lockfile --ignore-scripts' 'install --ignore-workspace --frozen-lockfile --ignore-scripts'
 run_case yarn false true 'install --ignore-scripts' 'install --ignore-scripts'
+
+run_workspace_case pnpm false false 'install'
+run_workspace_case pnpm true false 'install --frozen-lockfile'
+run_workspace_case pnpm false true 'install --ignore-scripts'
+run_workspace_case pnpm true true 'install --frozen-lockfile --ignore-scripts'
 
 printf 'install-packages helper tests passed\n'


### PR DESCRIPTION
## Summary

Update the pnpm package install helper so it distinguishes between standalone package directories and directories that are themselves pnpm workspace roots.

## What changed

- `scripts/install-packages.sh`
  - Only adds `--ignore-workspace` when the target directory is not a pnpm workspace root.
  - Preserves the existing frozen-lockfile and ignore-scripts combinations.
  - Allows genuine workspace roots to run a normal workspace install and materialize the full package set.

- `tests/test-install-packages.sh`
  - Adds coverage for pnpm targets that contain `pnpm-workspace.yaml`.
  - Verifies all flag combinations for workspace-root installs.
  - Keeps the existing standalone target behavior checks in place.

- `pnpm-packages/README.md`
  - Documents the new pnpm behavior for workspace roots vs. nested standalone projects.

## Behavior notes

- Standalone pnpm projects nested under a parent workspace still use `--ignore-workspace` to avoid walking up and mutating the parent workspace.
- pnpm workspace roots no longer receive `--ignore-workspace`, so normal monorepo installs work as expected.

## Testing

- Updated shell test coverage for the install helper to validate both standalone and workspace-root pnpm cases.