### PR TITLE
Add Confluence docs deployment workflow

### DIFF
--- a/.github/workflows/deploy-confluence.yml
+++ b/.github/workflows/deploy-confluence.yml
@@ -1,0 +1,37 @@
+name: Deploy docs to Confluence
+
+on:
+  push:
+    branches:
+    - main
+    paths:
+    - .github/workflows/deploy-confluence.yml
+    - docs/**
+    - confluence/**
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-confluence:
+    runs-on: ubuntu-24.04
+    environment: confluence
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+    - name: Setup Tools
+      uses: ./.github/actions/setup-tools
+
+    - name: Setup NPM Packages
+      uses: ./.github/actions/setup-npm
+
+    - name: Sync Docs to Confluence
+      uses: ./confluence
+      with:
+        folder: docs
+        username: ${{ secrets.CONFLUENCE_USERNAME }}
+        api-token: ${{ secrets.CONFLUENCE_API_TOKEN }}
+        confluence-base-url: ${{ secrets.CONFLUENCE_BASE_URL }}
+        space-key: ${{ secrets.CONFLUENCE_SPACE_KEY }}
+        parent-page-id: ${{ secrets.CONFLUENCE_PARENT_PAGE_ID }}


### PR DESCRIPTION
## Summary
Add a new GitHub Actions workflow to deploy documentation from the repository to Confluence.

## What changed
- Introduce a `Deploy docs to Confluence` workflow.
- Trigger the workflow on pushes to `main` when docs or the workflow file change, plus manual dispatch.
- Run the job on `ubuntu-24.04` with the `confluence` environment.
- Reuse existing setup actions for tools and npm dependencies.
- Sync the `docs` folder to Confluence using the configured secrets and page metadata.

## Notes
- The workflow is scoped to the `docs/**` and `confluence/**` paths so it only runs when relevant content changes.
- Required secrets include the Confluence username, API token, base URL, space key, and parent page ID.