### PR TITLE
Add gated Docker publication workflow support

### DIFF
--- a/.github/workflows/test-docker-build-push.yml
+++ b/.github/workflows/test-docker-build-push.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
     - .github/workflows/test-docker-build-push.yml
+    - action.yml
     - docker-build-push/**
     - tests/fixtures/docker-build-push/**
   push:
@@ -11,6 +12,7 @@ on:
     - main
     paths:
     - .github/workflows/test-docker-build-push.yml
+    - action.yml
     - docker-build-push/**
     - tests/fixtures/docker-build-push/**
   workflow_dispatch:
@@ -68,3 +70,53 @@ jobs:
         IMAGE_TAG: ${{ env.IMAGE_TAG }}
       run: |
         docker pull "$FULL_IMAGE:$IMAGE_TAG"
+
+  gated-registry-test:
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    services:
+      registry:
+        image: registry:2.8.3
+        ports:
+        - 5000:5000
+
+    env:
+      IMAGE_NAME: actions/docker-build-push-test
+      IMAGE_TAG: test-${{ github.run_id }}
+      TEST_REGISTRY: localhost:5000
+
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+    - name: Build, check, and push fixture image
+      id: build
+      uses: ./docker-build-push
+      with:
+        registry-url: ${{ env.TEST_REGISTRY }}
+        registry-login: 'false'
+        image-name: ${{ env.IMAGE_NAME }}
+        metadata-tags: |
+          type=raw,value=${{ env.IMAGE_TAG }}
+        metadata-labels: |
+          org.opencontainers.image.revision=${{ github.sha }}
+        docker-context: ./tests/fixtures/docker-build-push
+        docker-file: ./tests/fixtures/docker-build-push/Dockerfile
+        publish-mode: gated
+        pre-push-command: |
+          test "$(docker image inspect "$IMAGE_REF" --format '{{ index .Config.Labels "org.opencontainers.image.revision" }}')" = "$GITHUB_SHA"
+
+    - name: Verify gated outputs and alternate registry publication
+      env:
+        EXPECTED_REF: ${{ env.TEST_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
+        IMAGE_CONFIG_DIGEST: ${{ steps.build.outputs.image-config-digest }}
+        IMAGE_REF: ${{ steps.build.outputs.image-ref }}
+        MANIFEST_DIGEST: ${{ steps.build.outputs.manifest-digest }}
+      run: |
+        set -euo pipefail
+        test "$IMAGE_REF" = "$EXPECTED_REF"
+        [[ "$IMAGE_CONFIG_DIGEST" == sha256:* ]]
+        [[ "$MANIFEST_DIGEST" == sha256:* ]]
+        docker image rm "$EXPECTED_REF"
+        docker pull "$EXPECTED_REF"
+      shell: bash

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
-nodejs 26.5.0
+nodejs 26.7.0
 python 3.14.6
-pnpm 11.19.0
+pnpm 11.23.0
 act 0.2.89
 actionlint 1.7.12
 shellcheck 0.11.0

--- a/action.yml
+++ b/action.yml
@@ -7,10 +7,14 @@ inputs:
     required: true
   registry-username:
     description: Docker container registry username
-    required: true
+    required: false
   registry-password:
     description: Docker container registry password
-    required: true
+    required: false
+  registry-login:
+    description: Log in to the container registry before publishing
+    required: false
+    default: 'true'
   image-name:
     description: Docker image name
     required: true
@@ -38,10 +42,41 @@ inputs:
   docker-outputs:
     description: List of output destinations
     required: false
+  publish-mode:
+    description: Publication mode; direct preserves the original build-and-push behavior, gated scans a local single-platform image before pushing it
+    required: false
+    default: direct
+  pre-push-command:
+    description: Trusted shell command run against IMAGE_REF and IMAGE_CONFIG_DIGEST after the gated local build and before scanning or publishing
+    required: false
   trivy:
     description: Run Trivy vulnerability scanner
     required: false
     default: 'false'
+  trivy-severity:
+    description: Comma-separated severities that fail a gated Trivy scan
+    required: false
+    default: HIGH,CRITICAL
+  trivy-ignore-unfixed:
+    description: Ignore vulnerabilities without fixes during a gated Trivy scan
+    required: false
+    default: 'true'
+  trivy-sarif-file:
+    description: Path for the Trivy SARIF report
+    required: false
+    default: trivy-results.sarif
+  upload-sarif:
+    description: Upload the Trivy SARIF report to GitHub code scanning
+    required: false
+    default: 'true'
+  sbom:
+    description: Generate an SPDX JSON SBOM from the gated local image
+    required: false
+    default: 'false'
+  sbom-file:
+    description: Path for the generated SPDX JSON SBOM
+    required: false
+    default: image-sbom.spdx.json
 
 outputs:
   docker-version:
@@ -71,6 +106,18 @@ outputs:
   bake-file:
     description: Bake definition file with tags and labels
     value: ${{ steps.delegate.outputs.bake-file }}
+  image-ref:
+    description: Primary local image reference used by gated publication
+    value: ${{ steps.delegate.outputs.image-ref }}
+  image-config-digest:
+    description: Config digest of the local image used by gated publication
+    value: ${{ steps.delegate.outputs.image-config-digest }}
+  manifest-digest:
+    description: Published primary manifest digest
+    value: ${{ steps.delegate.outputs.manifest-digest }}
+  sbom-path:
+    description: Path to the generated image SBOM when enabled
+    value: ${{ steps.delegate.outputs.sbom-path }}
 
 runs:
   using: composite
@@ -82,6 +129,7 @@ runs:
       registry-url: ${{ inputs.registry-url }}
       registry-username: ${{ inputs.registry-username }}
       registry-password: ${{ inputs.registry-password }}
+      registry-login: ${{ inputs.registry-login }}
       image-name: ${{ inputs.image-name }}
       metadata-tags: ${{ inputs.metadata-tags }}
       metadata-labels: ${{ inputs.metadata-labels }}
@@ -91,4 +139,12 @@ runs:
       docker-file: ${{ inputs.docker-file }}
       docker-args: ${{ inputs.docker-args }}
       docker-outputs: ${{ inputs.docker-outputs }}
+      publish-mode: ${{ inputs.publish-mode }}
+      pre-push-command: ${{ inputs.pre-push-command }}
       trivy: ${{ inputs.trivy }}
+      trivy-severity: ${{ inputs.trivy-severity }}
+      trivy-ignore-unfixed: ${{ inputs.trivy-ignore-unfixed }}
+      trivy-sarif-file: ${{ inputs.trivy-sarif-file }}
+      upload-sarif: ${{ inputs.upload-sarif }}
+      sbom: ${{ inputs.sbom }}
+      sbom-file: ${{ inputs.sbom-file }}

--- a/docker-build-push/README.md
+++ b/docker-build-push/README.md
@@ -1,6 +1,6 @@
 # Docker Build Push
 
-Builds a Docker image, pushes it to a registry, and exposes the generated Docker metadata as action outputs.
+Builds a Docker image, pushes it to any OCI-compatible registry, and exposes generated metadata and image digests as action outputs.
 
 ## What It Does
 
@@ -8,7 +8,9 @@ Builds a Docker image, pushes it to a registry, and exposes the generated Docker
 - Generates tags, labels, and annotations with `docker/metadata-action`.
 - Builds and pushes the image with `docker/build-push-action`.
 - Reuses a local Buildx layer cache between runs.
-- Optionally runs Trivy and uploads SARIF results to the GitHub Security tab.
+- Supports the backward-compatible `direct` build-and-push mode.
+- Supports a single-platform `gated` mode that builds locally, runs optional pre-push checks and Trivy, then pushes and verifies the exact local image config digest.
+- Optionally generates an SPDX JSON SBOM and uploads SARIF results to the GitHub Security tab.
 
 ## Usage
 
@@ -62,6 +64,43 @@ jobs:
     trivy: 'true'
 ```
 
+`direct` is the default mode for compatibility. Its Trivy scan runs after the image is pushed.
+
+### Scan Before Publishing
+
+Use `gated` mode when registry tags must not change until checks pass:
+
+```yaml
+- name: Build, scan, and publish the verified image
+  id: image
+  uses: egose/actions/docker-build-push@main
+  with:
+    registry-url: registry.example.com
+    registry-username: ${{ secrets.REGISTRY_USERNAME }}
+    registry-password: ${{ secrets.REGISTRY_PASSWORD }}
+    image-name: team/myapp
+    metadata-tags: |
+      type=semver,pattern={{version}}
+      type=semver,pattern={{major}}.{{minor}}
+    metadata-labels: |
+      org.opencontainers.image.revision=${{ github.sha }}
+    docker-context: .
+    publish-mode: gated
+    pre-push-command: docker run --rm "$IMAGE_REF" myapp --version
+    trivy: 'true'
+    sbom: 'true'
+
+- name: Use the verified publication outputs
+  run: |
+    printf 'Image: %s\n' "$IMAGE_REF"
+    printf 'Manifest: %s\n' "$MANIFEST_DIGEST"
+  env:
+    IMAGE_REF: ${{ steps.image.outputs.image-ref }}
+    MANIFEST_DIGEST: ${{ steps.image.outputs.manifest-digest }}
+```
+
+The registry host is not tied to GHCR. For an already-authenticated Docker client or an unauthenticated local registry, set `registry-login: 'false'` and omit credentials.
+
 ### Share Metadata Between Labels And Annotations
 
 ```yaml
@@ -86,8 +125,9 @@ jobs:
 | Name | Required | Default | Description |
 | --- | --- | --- | --- |
 | `registry-url` | Yes |  | Container registry hostname, for example `ghcr.io`. |
-| `registry-username` | Yes |  | Username used to log in to the registry. |
-| `registry-password` | Yes |  | Password or token used to log in to the registry. |
+| `registry-username` | When logging in |  | Username used to log in to the registry. |
+| `registry-password` | When logging in |  | Password or token used to log in to the registry. |
+| `registry-login` | No | `"true"` | Log in before publishing. Set to `"false"` for an already-authenticated client or an unauthenticated local registry. |
 | `image-name` | Yes |  | Image name without the registry prefix. |
 | `metadata-tags` | Yes |  | Newline-separated tag rules in `docker/metadata-action` format. |
 | `metadata-labels` | No |  | Newline-separated label rules in `docker/metadata-action` format. |
@@ -96,8 +136,16 @@ jobs:
 | `docker-context` | No |  | Build context passed to `docker/build-push-action`. |
 | `docker-file` | No |  | Path to the Dockerfile. |
 | `docker-args` | No |  | Additional build args. `BUILD_TIMESTAMP` is always injected automatically. |
-| `docker-outputs` | No |  | Output destinations passed through to `docker/build-push-action`. |
-| `trivy` | No | `"false"` | Runs Trivy, converts the report to SARIF, and uploads it when set to `true`. |
+| `docker-outputs` | No |  | Output destinations passed through to `docker/build-push-action` in `direct` mode. Unsupported in `gated` mode. |
+| `publish-mode` | No | `direct` | `direct` builds and pushes immediately; `gated` builds and checks a local single-platform image before publishing it unchanged. |
+| `pre-push-command` | No |  | Trusted shell command run in `gated` mode with `IMAGE_REF` and `IMAGE_CONFIG_DIGEST` available. |
+| `trivy` | No | `"false"` | Runs Trivy after push in `direct` mode or as a hard pre-push gate in `gated` mode. |
+| `trivy-severity` | No | `HIGH,CRITICAL` | Comma-separated severities that fail a gated scan. |
+| `trivy-ignore-unfixed` | No | `"true"` | Ignore vulnerabilities without fixes during a gated scan. |
+| `trivy-sarif-file` | No | `trivy-results.sarif` | Path for the Trivy SARIF report in gated mode. |
+| `upload-sarif` | No | `"true"` | Upload Trivy SARIF to GitHub code scanning. |
+| `sbom` | No | `"false"` | Generate an SPDX JSON SBOM from the gated local image. |
+| `sbom-file` | No | `image-sbom.spdx.json` | Path for the generated image SBOM. |
 
 ## Outputs
 
@@ -112,10 +160,19 @@ jobs:
 | `bake-file-labels` | Bake definition file containing generated labels. |
 | `bake-file-annotations` | Bake definition file containing generated annotations. |
 | `bake-file` | Bake definition file containing generated tags, labels, and annotations. |
+| `image-ref` | Primary local image reference in gated mode. |
+| `image-config-digest` | Config digest of the checked local image in gated mode. |
+| `manifest-digest` | Primary manifest digest reported after publication. |
+| `sbom-path` | Generated image SBOM path when enabled. |
 
 ## Notes
 
-- This action always pushes the built image. There is no build-only mode.
 - The image reference is constructed as `${{ inputs.registry-url }}/${{ inputs.image-name }}`.
+- `registry-url` must be a registry host such as `ghcr.io`, `registry.example.com:5000`, or `docker.io`; do not include a URL scheme or trailing slash.
 - `metadata-labels-annotations` is appended to both `labels` and `annotations` for `docker/metadata-action`, then the specific input is appended after it so `metadata-labels` and `metadata-annotations` override shared keys.
-- The Trivy steps require `security-events: write` permission if you want SARIF uploaded to GitHub code scanning.
+- Gated mode supports one runner-native platform because it loads and tests the image with Docker before publication. Use direct mode for custom or multi-platform Buildx outputs.
+- Gated mode rejects metadata annotations because loading an image into Docker does not preserve manifest annotations. OCI labels are supported.
+- Gated mode authenticates only after the local checks and vulnerability gate pass, pushes each generated tag from the same local image, and verifies every remote manifest config digest against the local config digest.
+- `pre-push-command` is executable code and should only contain trusted workflow configuration. The command receives `IMAGE_REF` and `IMAGE_CONFIG_DIGEST`.
+- The Trivy upload requires `security-events: write`. Set `upload-sarif: 'false'` when that GitHub-specific integration is unavailable or unwanted.
+- Registry-specific signing and attestations remain caller responsibilities. The `manifest-digest` output can be passed to the registry's supported attestation tooling.

--- a/docker-build-push/action.yml
+++ b/docker-build-push/action.yml
@@ -7,10 +7,14 @@ inputs:
     required: true
   registry-username:
     description: Docker container registry username
-    required: true
+    required: false
   registry-password:
     description: Docker container registry password
-    required: true
+    required: false
+  registry-login:
+    description: Log in to the container registry before publishing
+    required: false
+    default: 'true'
   image-name:
     description: Docker image name
     required: true
@@ -38,10 +42,41 @@ inputs:
   docker-outputs:
     description: List of output destinations
     required: false
+  publish-mode:
+    description: Publication mode; direct preserves the original build-and-push behavior, gated scans a local single-platform image before pushing it
+    required: false
+    default: direct
+  pre-push-command:
+    description: Trusted shell command run against IMAGE_REF and IMAGE_CONFIG_DIGEST after the gated local build and before scanning or publishing
+    required: false
   trivy:
     description: Run Trivy vulnerability scanner
     required: false
     default: 'false'
+  trivy-severity:
+    description: Comma-separated severities that fail a gated Trivy scan
+    required: false
+    default: HIGH,CRITICAL
+  trivy-ignore-unfixed:
+    description: Ignore vulnerabilities without fixes during a gated Trivy scan
+    required: false
+    default: 'true'
+  trivy-sarif-file:
+    description: Path for the Trivy SARIF report
+    required: false
+    default: trivy-results.sarif
+  upload-sarif:
+    description: Upload the Trivy SARIF report to GitHub code scanning
+    required: false
+    default: 'true'
+  sbom:
+    description: Generate an SPDX JSON SBOM from the gated local image
+    required: false
+    default: 'false'
+  sbom-file:
+    description: Path for the generated SPDX JSON SBOM
+    required: false
+    default: image-sbom.spdx.json
 
 outputs:
   docker-version:
@@ -71,11 +106,62 @@ outputs:
   bake-file:
     description: Bake definition file with tags and labels
     value: ${{ steps.meta.outputs.bake-file }}
+  image-ref:
+    description: Primary local image reference used by gated publication
+    value: ${{ steps.local-image.outputs.image-ref }}
+  image-config-digest:
+    description: Config digest of the local image used by gated publication
+    value: ${{ steps.local-image.outputs.config-digest }}
+  manifest-digest:
+    description: Published primary manifest digest
+    value: ${{ steps.publish.outputs.manifest-digest || steps.build-direct.outputs.digest }}
+  sbom-path:
+    description: Path to the generated image SBOM when enabled
+    value: ${{ steps.sbom-output.outputs.path }}
 
 runs:
   using: composite
   steps:
+  - name: Validate inputs
+    env:
+      DOCKER_OUTPUTS: ${{ inputs.docker-outputs }}
+      METADATA_ANNOTATIONS: ${{ inputs.metadata-annotations }}
+      METADATA_LABELS_ANNOTATIONS: ${{ inputs.metadata-labels-annotations }}
+      PUBLISH_MODE: ${{ inputs.publish-mode }}
+      REGISTRY_LOGIN: ${{ inputs.registry-login }}
+      REGISTRY_PASSWORD: ${{ inputs.registry-password }}
+      REGISTRY_URL: ${{ inputs.registry-url }}
+      REGISTRY_USERNAME: ${{ inputs.registry-username }}
+    run: |
+      set -euo pipefail
+
+      case "$PUBLISH_MODE" in
+        direct|gated) ;;
+        *) printf 'publish-mode must be direct or gated, got %s\n' "$PUBLISH_MODE" >&2; exit 1 ;;
+      esac
+      case "$REGISTRY_LOGIN" in
+        true|false) ;;
+        *) printf 'registry-login must be true or false, got %s\n' "$REGISTRY_LOGIN" >&2; exit 1 ;;
+      esac
+      case "$REGISTRY_URL" in
+        ''|*://*|*/) printf 'registry-url must be a registry host without a scheme or trailing slash, got %s\n' "$REGISTRY_URL" >&2; exit 1 ;;
+      esac
+      if [[ "$REGISTRY_LOGIN" == true && ( -z "$REGISTRY_USERNAME" || -z "$REGISTRY_PASSWORD" ) ]]; then
+        printf 'registry-username and registry-password are required when registry-login is true\n' >&2
+        exit 1
+      fi
+      if [[ "$PUBLISH_MODE" == gated && -n "$DOCKER_OUTPUTS" ]]; then
+        printf 'docker-outputs is not supported in gated mode because the scanned local image must be pushed unchanged\n' >&2
+        exit 1
+      fi
+      if [[ "$PUBLISH_MODE" == gated && ( -n "$METADATA_ANNOTATIONS" || -n "$METADATA_LABELS_ANNOTATIONS" ) ]]; then
+        printf 'metadata annotations are not supported in gated mode because Docker image load does not preserve manifest annotations\n' >&2
+        exit 1
+      fi
+    shell: bash
+
   - name: Log in to Docker Container Registry
+    if: ${{ inputs.publish-mode == 'direct' && inputs.registry-login == 'true' }}
     # See https://github.com/docker/login-action/commits/master/
     uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
     with:
@@ -117,7 +203,9 @@ runs:
       key: ${{ runner.os }}-buildx-${{ inputs.image-name }}-${{ github.sha }}
       restore-keys: ${{ runner.os }}-buildx-${{ inputs.image-name }}
 
-  - name: Build and push Docker image
+  - id: build-direct
+    name: Build and push Docker image
+    if: ${{ inputs.publish-mode == 'direct' }}
     # See https://github.com/docker/build-push-action/commits/master/
     uses: docker/build-push-action@83bfd93ab480705a7b99a2ed02765137f5ab55ba
     with:
@@ -135,14 +223,154 @@ runs:
       cache-from: type=local,src=${{ env.DOCKER_LAYERS_PATH }}
       cache-to: type=local,dest=${{ env.DOCKER_LAYERS_PATH }}-new
 
+  - name: Build local image for gated publication
+    if: ${{ inputs.publish-mode == 'gated' }}
+    # See https://github.com/docker/build-push-action/commits/master/
+    uses: docker/build-push-action@83bfd93ab480705a7b99a2ed02765137f5ab55ba
+    with:
+      context: ${{ inputs.docker-context }}
+      file: ${{ inputs.docker-file }}
+      load: true
+      push: false
+      provenance: false
+      tags: ${{ steps.meta.outputs.tags }}
+      build-args: |
+        BUILD_TIMESTAMP=${{ env.BUILD_TIMESTAMP }}
+        ${{ inputs.docker-args }}
+      labels: ${{ steps.meta.outputs.labels }}
+      cache-from: type=local,src=${{ env.DOCKER_LAYERS_PATH }}
+      cache-to: type=local,dest=${{ env.DOCKER_LAYERS_PATH }}-new
+
   - name: Move Docker layers cache
     run: |
       rm -rf ${{ env.DOCKER_LAYERS_PATH }}
       mv ${{ env.DOCKER_LAYERS_PATH }}-new ${{ env.DOCKER_LAYERS_PATH }}
     shell: bash
 
+  - id: local-image
+    name: Record local image identity
+    if: ${{ inputs.publish-mode == 'gated' }}
+    env:
+      DOCKER_TAGS: ${{ steps.meta.outputs.tags }}
+    run: |
+      set -euo pipefail
+
+      image_ref="$(printf '%s\n' "$DOCKER_TAGS" | while IFS= read -r tag; do if [[ -n "$tag" ]]; then printf '%s\n' "$tag"; break; fi; done)"
+      if [[ -z "$image_ref" ]]; then
+        printf 'docker/metadata-action generated no image tags\n' >&2
+        exit 1
+      fi
+      config_digest="$(docker image inspect "$image_ref" --format '{{.Id}}')"
+      printf 'image-ref=%s\n' "$image_ref" >> "$GITHUB_OUTPUT"
+      printf 'config-digest=%s\n' "$config_digest" >> "$GITHUB_OUTPUT"
+      {
+        printf '### Container pre-publish evidence\n'
+        printf -- '- Local image: `%s`\n' "$image_ref"
+        printf -- '- Local image config digest: `%s`\n' "$config_digest"
+      } >> "$GITHUB_STEP_SUMMARY"
+    shell: bash
+
+  - name: Run pre-push checks
+    if: ${{ inputs.publish-mode == 'gated' && inputs.pre-push-command != '' }}
+    env:
+      IMAGE_CONFIG_DIGEST: ${{ steps.local-image.outputs.config-digest }}
+      IMAGE_REF: ${{ steps.local-image.outputs.image-ref }}
+      PRE_PUSH_COMMAND: ${{ inputs.pre-push-command }}
+    run: bash -euo pipefail -c "$PRE_PUSH_COMMAND"
+    shell: bash
+
+  - id: gated-scan
+    name: Scan local image before publishing
+    if: ${{ inputs.publish-mode == 'gated' && inputs.trivy == 'true' }}
+    continue-on-error: true
+    # See https://github.com/aquasecurity/trivy-action/commits/master/
+    uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+    with:
+      image-ref: ${{ steps.local-image.outputs.image-ref }}
+      format: sarif
+      output: ${{ inputs.trivy-sarif-file }}
+      exit-code: 1
+      ignore-unfixed: ${{ inputs.trivy-ignore-unfixed }}
+      severity: ${{ inputs.trivy-severity }}
+
+  - name: Upload gated Trivy scan results
+    if: ${{ always() && inputs.publish-mode == 'gated' && inputs.trivy == 'true' && inputs.upload-sarif == 'true' }}
+    # See https://github.com/github/codeql-action/commits/main/
+    uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd
+    with:
+      sarif_file: ${{ inputs.trivy-sarif-file }}
+
+  - name: Enforce gated Trivy result
+    if: ${{ inputs.publish-mode == 'gated' && inputs.trivy == 'true' && steps.gated-scan.outcome != 'success' }}
+    run: |
+      printf 'The pre-publish Trivy scan failed; no registry tags were changed.\n' >&2
+      exit 1
+    shell: bash
+
+  - name: Generate image SBOM
+    if: ${{ inputs.publish-mode == 'gated' && inputs.sbom == 'true' }}
+    # See https://github.com/aquasecurity/trivy-action/commits/master/
+    uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25
+    with:
+      image-ref: ${{ steps.local-image.outputs.image-ref }}
+      format: spdx-json
+      output: ${{ inputs.sbom-file }}
+      exit-code: 0
+
+  - id: sbom-output
+    name: Record image SBOM path
+    if: ${{ inputs.publish-mode == 'gated' && inputs.sbom == 'true' }}
+    env:
+      SBOM_FILE: ${{ inputs.sbom-file }}
+    run: printf 'path=%s\n' "$SBOM_FILE" >> "$GITHUB_OUTPUT"
+    shell: bash
+
+  - name: Log in for gated publication
+    if: ${{ inputs.publish-mode == 'gated' && inputs.registry-login == 'true' }}
+    # See https://github.com/docker/login-action/commits/master/
+    uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+    with:
+      registry: ${{ inputs.registry-url }}
+      username: ${{ inputs.registry-username }}
+      password: ${{ inputs.registry-password }}
+
+  - id: publish
+    name: Push and verify gated image
+    if: ${{ inputs.publish-mode == 'gated' }}
+    env:
+      DOCKER_TAGS: ${{ steps.meta.outputs.tags }}
+      IMAGE_CONFIG_DIGEST: ${{ steps.local-image.outputs.config-digest }}
+      IMAGE_REF: ${{ steps.local-image.outputs.image-ref }}
+    run: |
+      set -euo pipefail
+
+      while IFS= read -r tag; do
+        [[ -n "$tag" ]] || continue
+        docker image push "$tag"
+      done <<< "$DOCKER_TAGS"
+
+      manifest_digest="$(docker buildx imagetools inspect "$IMAGE_REF" --format '{{.Manifest.Digest}}')"
+      {
+        printf '### Container publish evidence\n'
+        printf -- '- Published primary image: `%s@%s`\n' "${IMAGE_REF%:*}" "$manifest_digest"
+      } >> "$GITHUB_STEP_SUMMARY"
+
+      while IFS= read -r tag; do
+        [[ -n "$tag" ]] || continue
+        published_config_digest="$(docker buildx imagetools inspect "$tag" --format '{{.Manifest.Config.Digest}}')"
+        published_manifest_digest="$(docker buildx imagetools inspect "$tag" --format '{{.Manifest.Digest}}')"
+        if [[ "$published_config_digest" != "$IMAGE_CONFIG_DIGEST" ]]; then
+          printf 'Published digest mismatch for %s: local %s, published %s\n' "$tag" "$IMAGE_CONFIG_DIGEST" "$published_config_digest" >&2
+          exit 1
+        fi
+        printf -- '- `%s`: manifest `%s`, config digest matches local `%s`\n' "$tag" "$published_manifest_digest" "$published_config_digest" >> "$GITHUB_STEP_SUMMARY"
+      done <<< "$DOCKER_TAGS"
+
+      printf 'manifest-digest=%s\n' "$manifest_digest" >> "$GITHUB_OUTPUT"
+    shell: bash
+
   - name: Run Trivy vulnerability scanner
-    if: ${{ inputs.trivy == 'true' }}
+    if: ${{ inputs.publish-mode == 'direct' && inputs.trivy == 'true' }}
     # See https://github.com/aquasecurity/trivy-action/commits/master/
     uses: aquasecurity/trivy-action@1bd062560b422f5944df1de50abd05162bea079e
     with:
@@ -151,7 +379,7 @@ runs:
       output: trivy-results.json
 
   - name: Convert Trivy JSON report into sarif
-    if: ${{ inputs.trivy == 'true' }}
+    if: ${{ inputs.publish-mode == 'direct' && inputs.trivy == 'true' }}
     run: |
       trivy convert --format sarif --output trivy-results.sarif trivy-results.json
       trivy convert --format table --output trivy-results.table trivy-results.json
@@ -170,7 +398,7 @@ runs:
     shell: bash
 
   - name: Upload Trivy scan results to GitHub Security tab
-    if: ${{ inputs.trivy == 'true' }}
+    if: ${{ inputs.publish-mode == 'direct' && inputs.trivy == 'true' && inputs.upload-sarif == 'true' }}
     # See https://github.com/github/codeql-action/commits/main/
     uses: github/codeql-action/upload-sarif@34950e1b113b30df4edee1a6d3a605242df0c40b
     with:

--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
     "changelog": "repo-toolkit-changelog"
   },
   "devDependencies": {
-    "@commitlint/cli": "^21.2.1",
-    "@commitlint/config-conventional": "^21.2.0",
-    "@commitlint/format": "^21.2.0",
+    "@commitlint/cli": "^21.2.2",
+    "@commitlint/config-conventional": "^21.2.2",
+    "@commitlint/format": "^21.2.2",
     "@release-it/bumper": "^8.0.0",
-    "@repo-toolkit/changelog": "^0.9.0",
-    "@repo-toolkit/confluence": "^0.9.0",
-    "release-it": "^21.0.1"
+    "@repo-toolkit/changelog": "^0.13.0",
+    "@repo-toolkit/confluence": "^0.13.0",
+    "release-it": "^21.0.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,26 +9,26 @@ importers:
   .:
     devDependencies:
       '@commitlint/cli':
-        specifier: ^21.2.1
-        version: 21.2.1(@types/node@25.6.0)(conventional-commits-parser@6.4.0)(typescript@6.0.3)
+        specifier: ^21.2.2
+        version: 21.2.2(@types/node@25.6.0)(conventional-commits-parser@6.4.0)(typescript@6.0.3)
       '@commitlint/config-conventional':
-        specifier: ^21.2.0
-        version: 21.2.0
+        specifier: ^21.2.2
+        version: 21.2.2
       '@commitlint/format':
-        specifier: ^21.2.0
-        version: 21.2.0
+        specifier: ^21.2.2
+        version: 21.2.2
       '@release-it/bumper':
         specifier: ^8.0.0
-        version: 8.0.0(release-it@21.0.1(@types/node@25.6.0))
+        version: 8.0.0(release-it@21.0.2(@types/node@25.6.0))
       '@repo-toolkit/changelog':
-        specifier: ^0.9.0
-        version: 0.9.0
+        specifier: ^0.13.0
+        version: 0.13.0
       '@repo-toolkit/confluence':
-        specifier: ^0.9.0
-        version: 0.9.0
+        specifier: ^0.13.0
+        version: 0.13.0
       release-it:
-        specifier: ^21.0.1
-        version: 21.0.1(@types/node@25.6.0)
+        specifier: ^21.0.2
+        version: 21.0.2(@types/node@25.6.0)
 
 packages:
 
@@ -48,13 +48,13 @@ packages:
     resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
 
-  '@commitlint/cli@21.2.1':
-    resolution: {integrity: sha512-blsZGe29hJ72VGEFVl72IVYX+1vsfINpjA9yWQA6i7OKD/McGEOXg08sKIRKjFk4JvzhV/9n0l3i6NooPLTNfg==}
+  '@commitlint/cli@21.2.2':
+    resolution: {integrity: sha512-a+6hQxIxnpdvSvS2apvttPNbEliYsVC3PqFYDiiB2kjbwIsQsj1urvQ4Tkf70pKYozPalKAuRQmm/GHwndduqA==}
     engines: {node: '>=22.12.0'}
     hasBin: true
 
-  '@commitlint/config-conventional@21.2.0':
-    resolution: {integrity: sha512-Qf8WRDVcyVd14if6VTWenebxFbKnVnbzPUJjlzjkyJGeHK2xCGd63Dr1XZzj0plXKQb9P0BfOxoc1HVeCo2BWQ==}
+  '@commitlint/config-conventional@21.2.2':
+    resolution: {integrity: sha512-NxA37SZviusFUEYOQZ5hNnZ1h7O/KiemPkxjOlpzKJNnWxThiwc6/SaZhaPa8fyLvfRBAywhQhJJk8XESHWlpQ==}
     engines: {node: '>=22.12.0'}
 
   '@commitlint/config-validator@21.2.0':
@@ -69,40 +69,40 @@ packages:
     resolution: {integrity: sha512-RifH+FmImozKBE6mozhF4K3r2RRKP7SMi/Q/zLCmExtp5e05lhHOUYqGBlFBAGNHaZxU/WYw1XuugYK9jQzqnA==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/format@21.2.0':
-    resolution: {integrity: sha512-c4q64xaav2U83t7k7RyzJerBZurPer7FxUOY0RL5L/6CZijZ7K+s6HIBGIghj0ey1P2+seRX0J9XQYtDued6tg==}
+  '@commitlint/format@21.2.2':
+    resolution: {integrity: sha512-v6fvxZSc/AvVMROlr3H34+1766bZSYApRUSCAMjWamStPjKMvZ8GdvVA5YW/VQNgbFTmcMz6OYmSTJEvIjPrfA==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/is-ignored@21.2.0':
-    resolution: {integrity: sha512-4/eB0vBN7L88O/oC4ajAEqi7j2ZfNgxl/+11RfAV9YosejZgDXhY2C9VcHnHJhOzPLoSy5P3Mg/46kqeyJfXKw==}
+  '@commitlint/is-ignored@21.2.2':
+    resolution: {integrity: sha512-9UoKNgfFE3LU7FrzierCvk3CdDfMDeVGC86qZiT/n0TIjfq/dmZ9MHuXd45OTNRa26ZanmJRxEtmiXk/lEJihg==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/lint@21.2.0':
-    resolution: {integrity: sha512-ceO5dp9pLjEZ6y6qbq/uXWXDPykqqlTsyzoQ0NzecpisSJhK3kTy9qzQoPeJuWG/IMNdV1lO0RgmzqoAlSi1uw==}
+  '@commitlint/lint@21.2.2':
+    resolution: {integrity: sha512-Fy8JxEBzdmsYWFude/61GxXu5O+wEymwiRK2z9GL9R8mCsXphCoGxAFc5iHn5mjlfcSrhiiONE+ksf4KOjnaPg==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/load@21.2.0':
-    resolution: {integrity: sha512-RjlzWQqruRwIenJEfZtq7kG97co97nKoHpflE5YnF61tDLXxHPrdWImgzw6VL6MlFyaOcVlk74eBV8ZQmc3oIA==}
+  '@commitlint/load@21.2.2':
+    resolution: {integrity: sha512-0Tt6wDPX167cjKC5D4zhm0+20wJJG+TN/TKovMOspfSe78rOnKX+MNzlVNiu6HyQPZChPJ8QBH31MVt6Bb8fCg==}
     engines: {node: '>=22.12.0'}
 
   '@commitlint/message@21.2.0':
     resolution: {integrity: sha512-YxGoiXD/HXNXLJPrQwE5poXa+XH0CBEm+mdvbHQP0g6MV/dmJyUFCzPNzZbxL93GvZ70TmtTK0Z0/IBpAqHv8g==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/parse@21.2.0':
-    resolution: {integrity: sha512-QHWxG4d0PLTF634/AdyZ0MQS+CLn5YOuJlCFhMMlSGKFxzYGUetkHBj18xgBD+6fVzUrA2lrCdi/vlS2f/oYXg==}
+  '@commitlint/parse@21.2.2':
+    resolution: {integrity: sha512-MEkobPfvRp+z06Wro8HMG1BDGHzZmj82A1LH1nWeG3ipHpg/x4m6v3wEDvMBIKjRFUnfR3nBeFs3MVCr7UdAmg==}
     engines: {node: '>=22.12.0'}
 
   '@commitlint/read@21.2.1':
     resolution: {integrity: sha512-hUW7EJQnNTL0vPOmVMNK4CrnrNBN0nN+JJHReFkdHO5y4iyHeEmTBwuC15OCqUTjxWo7idnH1LftfpWVIaPWIA==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/resolve-extends@21.2.0':
-    resolution: {integrity: sha512-4O/1j51+79Wth9s/MGxt/5gs0XYLDgNlYpltQfhAvLE0itusLKs9zruxbiNg1oOkmkb9L9L4USYGjEj7n87NxA==}
+  '@commitlint/resolve-extends@21.2.2':
+    resolution: {integrity: sha512-RPkJ/IFi7sMUUVbZLqwWFtWw/zRDcfFsmrPSiTMrt5wb7AdxOr86EGQFvmGzef5QKV5IPBWWCujqVTw1RWX44A==}
     engines: {node: '>=22.12.0'}
 
-  '@commitlint/rules@21.2.0':
-    resolution: {integrity: sha512-C2yXMNpiB8ETZKfx5JD8+ExgF8vTU1VQMKPSUUYwqKpw9oJWQBrlXBpdU038mj2WPjof7o9UzFpmTyBeGMZwZg==}
+  '@commitlint/rules@21.2.2':
+    resolution: {integrity: sha512-eplQzyYkBjYB1HyyRj8hkcK11Y9DU9nuBz7uOKEd6NpE9NGDytLFCAnlRE+OoiK/5sHEJsaz2RGhuWBvYzIbNA==}
     engines: {node: '>=22.12.0'}
 
   '@commitlint/to-lines@21.0.1':
@@ -129,20 +129,20 @@ packages:
       conventional-commits-parser:
         optional: true
 
-  '@conventional-changelog/git-client@3.1.0':
-    resolution: {integrity: sha512-Tqa/gHco2WJWa740NRjOrfKVvzIqxkZpecb8bemaQ8sKM5PXb1UK4uTyTb/1wIqNuOVaDOFxyBdhTIQZn6gdjQ==}
+  '@conventional-changelog/git-client@3.1.2':
+    resolution: {integrity: sha512-jZqwnJwf7nboIlAcw/mkOjVa6DexCcUOgT2oOQgkoi3z9vR8tGFkcMy2BFcYwjhL9sYcDDXkRQDayiDieCoW7A==}
     engines: {node: '>=22'}
     peerDependencies:
       conventional-commits-filter: ^6.0.1
-      conventional-commits-parser: ^7.0.1
+      conventional-commits-parser: ^7.1.2
     peerDependenciesMeta:
       conventional-commits-filter:
         optional: true
       conventional-commits-parser:
         optional: true
 
-  '@conventional-changelog/template@1.2.1':
-    resolution: {integrity: sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==}
+  '@conventional-changelog/template@1.4.0':
+    resolution: {integrity: sha512-aalGyl7dbB5PArRebDIX43ZvBlXrYm9uWzGJ26t+4SzJVPsOuvfILGGbw5X4yX7i50YEmJ8zvbiWnqH/AAnZqg==}
     engines: {node: '>=22'}
 
   '@decimalturn/toml-patch@2.1.0':
@@ -156,8 +156,8 @@ packages:
     resolution: {integrity: sha512-3eTuUO1vH2cZm2ZKHeQxnOqlTi9EfZDGgIe3BL3I4u+rJHocr9Fz86M4fjYABPvFnQG/gGK551HqDiIcETwU6Q==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
 
-  '@inquirer/checkbox@5.2.1':
-    resolution: {integrity: sha512-b6xmA/VlTe0ZgDQHDui+Nav470u7u49nRd8/iuhOcQPO9Ch7lGuogydhi2VOmNlZ+zXcM8IcPuNSwQcdJaF/kw==}
+  '@inquirer/checkbox@5.2.2':
+    resolution: {integrity: sha512-Y5/bAScMy5Y+9isCx0SKbyJebMCaXXX5em0kxkj115eZNscgV9srOHrgyfS0e5xAVymIfOh9piYBKDILktsMMg==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
@@ -165,8 +165,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/confirm@6.1.1':
-    resolution: {integrity: sha512-eb8DBZcz/2qHWQda4rk2JiQk5h9QV/cVHi1yjt0f69WFZMRFn0sJTye3EAP8icut8UDMjQPsaH5KbcOogefrFQ==}
+  '@inquirer/confirm@6.2.0':
+    resolution: {integrity: sha512-SKXarWrYhtpqOEctf9XGCGy29QjsvJAM0Aq9ZR9z4Ns94OmpqudOly+aSEfNqUf9SwsQaUgY9+Z8hyzG0xX8fw==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
@@ -174,8 +174,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/core@11.2.1':
-    resolution: {integrity: sha512-Qd6GJT1yVyrZZCfN8W2qKF5ApmqryXRhRKCuip8h01x2w/esJQ2XIYc6f9abMIHgKQdBfFTSOdbHRLAhuM09UA==}
+  '@inquirer/core@12.0.0':
+    resolution: {integrity: sha512-+nnvFEXIB08CZNVXpvW3B+zHW96QXvGUjNKJ8NJIPqAZi5Kd4WhYt2S3C234ReepG1qw2HOlEUbjYVHBowXObA==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
@@ -183,8 +183,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/editor@5.2.2':
-    resolution: {integrity: sha512-ZRVd/oD+sYsUd5zVm0NflqEzlqfYCyHNsqkHl2oWXEUHs12tCbcSFi+wVFEvD8+LGRaMUsVrE7qeo6lSG/S1Vg==}
+  '@inquirer/editor@5.3.0':
+    resolution: {integrity: sha512-nnsP/IdJ8s83q7ZuObmgn12QM+uLCkab9E0Oordojbn62WUg1c+v9Ou/F/057pgh0ppX0W+Hj5bO/Dp5hsxQtA==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
@@ -192,8 +192,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/expand@5.1.1':
-    resolution: {integrity: sha512-YmQpenjbFSHAK3sOd44puHh3V1KXXr+JiNpUztoSQ4drLh2rTVzTap/YtlAVu/5xavifIlBfNEzJ/neZJ1a/1g==}
+  '@inquirer/expand@5.1.2':
+    resolution: {integrity: sha512-OWIH1IyyWqEKIyqC9Xy+Bnga7NkGMovFdo4atYZMUOTRqf6rO2WCv9E/1MyzvOErDBCxs+9UFliRUDc50xs/jw==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
@@ -201,8 +201,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/external-editor@3.0.3':
-    resolution: {integrity: sha512-6thf5I8q7lZwzGLAxPaaGEREEkZ3nyePPDQ1oyobblxmEE8mqTLguScP7pDjUTAibiyb4hfXl+qjUEJ+di/aNA==}
+  '@inquirer/external-editor@3.0.4':
+    resolution: {integrity: sha512-tZbbaK2ovq6vlrRBNQvjrypmrED/p5x2ncIHQ79cD55tei3dD96v5glMMA+6tiq7K104i/25DVYKWVPJuV6ptA==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
@@ -210,21 +210,12 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/figures@2.0.7':
-    resolution: {integrity: sha512-aJ8TBPOGB6f/2qziPfElISTCEd5XOYTFckA2SGjhNmiKzfK/u4ot3v0DUzGVdUnKjN10EqnnEPck36BkyfLnJw==}
+  '@inquirer/figures@2.0.8':
+    resolution: {integrity: sha512-tApbon79GM9ry56ja/Ud3SY2CL4TQsao9fIwDQbgTeNY55025GdMzQ2+UdegV/lx51VNGUB59M0v0nMpybYY4Q==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
 
-  '@inquirer/input@5.1.2':
-    resolution: {integrity: sha512-9K/DDBSQpOyZSkt6sOVP9Vo0TR7atX2kuILsUu0x3wVcVbe97lJwIJKMLdMw25tDYuXl/qp6erT0Xs1rfmcfZg==}
-    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
-    peerDependencies:
-      '@types/node': '>=18'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-
-  '@inquirer/number@4.1.1':
-    resolution: {integrity: sha512-XF4IXAbPnGPgw0wsbC/i2tPcyfdZgDpUlhsqU0SfT4IRIGWha6Xm9VRgN5yYxJq+jnyXlfXI/nQ3ulfk0iEICA==}
+  '@inquirer/input@5.1.3':
+    resolution: {integrity: sha512-F/BZHtyEzP+HO+IGVd4AjBRgvX/ywm42bx8S0+dENk2YclzE9tJ3X/15THwtT6ehApmKvdYDMsVTuyyDod0gOQ==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
@@ -232,8 +223,17 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/password@5.1.1':
-    resolution: {integrity: sha512-3XBfF7DAsp5qeDsvN5Rd1HmbNokVvEQoUM0QLrRcybC9nX96w3Pbmu7qUsb3IT3J3jBvs2+mTXaKHOUsgHMLzg==}
+  '@inquirer/number@4.2.0':
+    resolution: {integrity: sha512-ew+fSDijsQ/WhD4TV3XLb+if400cDuzTzHfGR8sTNBXkK9CYDWoGE8fhaO8GbT312pNv1AJEOsDxy/z/HVettA==}
+    engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/password@5.1.2':
+    resolution: {integrity: sha512-nSdufycW8xynEVssFkNQEYIzTySilog0UlfOVRwh3pXzPSk4frXUT2jZWjHnKae6RU9PaoF9wfy1pGwewQuqGw==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
@@ -250,8 +250,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/rawlist@5.3.1':
-    resolution: {integrity: sha512-QqdTqQddL3qPX/PPrjobpsO25NZ4dWXgTLenrR445L2ptLEYE6Z+PD5c5CNDJNx4ugRgELAIpSIJxZaO2jJ2Og==}
+  '@inquirer/rawlist@5.3.2':
+    resolution: {integrity: sha512-oPSKrYK1X1bMkjXDzIKHUkJp195LFSfgbnVtXnjSKGFjrCbS6I+wyvfAZTwKE9BSt3HwWgfD7JfsXALBgCogzQ==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
@@ -259,8 +259,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/search@4.2.1':
-    resolution: {integrity: sha512-xJj8QWKRSrfKoBIITLZK61dD3zwo0Rz11fgDImku30/Oe81zMdIdGgrLY2h6RkJ+KZ/GhNYIRMKnH/62qBTA5g==}
+  '@inquirer/search@4.3.0':
+    resolution: {integrity: sha512-HFxXE5w727ctSUcAwrDquftJGjMgu36OeV5SHEXMlr2j/ahzmRX9xSEeVolV8tzYnTf45cg6vGkdMMRdm3RPhQ==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
@@ -268,8 +268,8 @@ packages:
       '@types/node':
         optional: true
 
-  '@inquirer/select@5.2.1':
-    resolution: {integrity: sha512-FlDndEUww8m7BfukO2nJa25vhD+H5jxxCv4oGioKqzyWz3nPHhhw4LKdYRSlXuAx7DsdWia7iyaBPKKS95Evfw==}
+  '@inquirer/select@5.2.2':
+    resolution: {integrity: sha512-RkI8dRHWt+bh04oLixvF1kFzKC7e5rqJoHKkzcqSHATebBXFC6GmrT8ddbVkgSzLV0HnHs2cPFuBINr8otij8Q==}
     engines: {node: '>=23.5.0 || ^22.13.0 || ^20.17.0'}
     peerDependencies:
       '@types/node': '>=18'
@@ -302,20 +302,23 @@ packages:
     resolution: {integrity: sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==}
     engines: {node: '>= 20'}
 
-  '@octokit/core@7.0.6':
-    resolution: {integrity: sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==}
+  '@octokit/core@7.0.7':
+    resolution: {integrity: sha512-DcB0M3KFgr9ECI328lhBMVsyFT2DnmNucSBTqEN3exyNKUzkkpUSCHmTRcunF41Eou2TIQKW4seewri8ON9bSA==}
     engines: {node: '>= 20'}
 
-  '@octokit/endpoint@11.0.3':
-    resolution: {integrity: sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==}
+  '@octokit/endpoint@11.0.4':
+    resolution: {integrity: sha512-f1cOWoHPmxryJFknxbtDdjODWfV8A9tc8Aae6ermXPNgHFZ/x91AtHIz4gicEjL8hkJiip+u21QHJORfBv/qiA==}
     engines: {node: '>= 20'}
 
-  '@octokit/graphql@9.0.3':
-    resolution: {integrity: sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==}
+  '@octokit/graphql@9.0.4':
+    resolution: {integrity: sha512-5s15CCiY8XXQ+FG+b1YQcl6Z2FA++nwAz/tg2VUrTmnMncP+2nnGUEYANImdnxsA2Fnq+Mbl7hDjUTw7cFAwcg==}
     engines: {node: '>= 20'}
 
   '@octokit/openapi-types@27.0.0':
     resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
+
+  '@octokit/openapi-types@28.0.0':
+    resolution: {integrity: sha512-0rFyLuyHvIj6uuZWuDslxkowFYdPXoNIkeAv4b27dzm2Tf4vGWXnPsMcxs7d65kLdMERgP3wc1AEPlqMz8e1cQ==}
 
   '@octokit/plugin-paginate-rest@14.0.0':
     resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
@@ -335,12 +338,12 @@ packages:
     peerDependencies:
       '@octokit/core': '>=6'
 
-  '@octokit/request-error@7.1.0':
-    resolution: {integrity: sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==}
+  '@octokit/request-error@7.1.1':
+    resolution: {integrity: sha512-+eaY7G2VVpSf2pc5Gn1+mph837V/d/TYTJAgWL9Tb0ogGYcpN3IlAVFgjL+Vv93F/sevrxkvsYCedtpLdcFLzA==}
     engines: {node: '>= 20'}
 
-  '@octokit/request@10.0.11':
-    resolution: {integrity: sha512-+s7HUxjfFqOMS9VlIwDffq0MikjSAK0gSpG73W+meAvVAvX4MBrHYTK5Bj3Uot55qFT4gzUtfzE4mGWY4Br8/Q==}
+  '@octokit/request@10.0.15':
+    resolution: {integrity: sha512-3CBg9aJ0hO9Pjyij8LbK/xYtEaPws9SW7xKz67daPNxQB1q5Y9OMA7DDOG0A6Hwf9ygGu3tvzusg0LXQ8/wAjA==}
     engines: {node: '>= 20'}
 
   '@octokit/rest@22.0.1':
@@ -349,6 +352,9 @@ packages:
 
   '@octokit/types@16.0.0':
     resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
+  '@octokit/types@17.0.0':
+    resolution: {integrity: sha512-ByP1v7YL5SMveFPP7+sj0/ZuWCOOg/Chs4NafOMpq6WNIM/hdGY0S7C0TCGDBWu1aGmOxmUIhMx3cO+IdwYZ1Q==}
 
   '@phun-ky/typeof@2.0.3':
     resolution: {integrity: sha512-oeQJs1aa8Ghke8JIK9yuq/+KjMiaYeDZ38jx7MhkXncXlUKjqQ3wEm2X3qCKyjo+ZZofZj+WsEEiqkTtRuE2xQ==}
@@ -360,18 +366,18 @@ packages:
     peerDependencies:
       release-it: ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0
 
-  '@repo-toolkit/changelog@0.9.0':
-    resolution: {integrity: sha512-EA5cOG1pV/JdX4j1JVC2nINvum6Yd1hOh+IE6niK0gpeB3IRDTe+rq3kmM4e7B4aUhuQko1ymhHqeAubUmYw6A==}
+  '@repo-toolkit/changelog@0.13.0':
+    resolution: {integrity: sha512-RHNK9jB/ojqzRpZ6h3v8vfa6q0xRg0GK3LvpX3/IUHwvn7VnWJRNUbsNK8E0/A7Aaz8Wfx9/mhPv+QuSf2c1zw==}
     engines: {node: '>=20'}
     hasBin: true
 
-  '@repo-toolkit/confluence@0.9.0':
-    resolution: {integrity: sha512-cWxQ6K+7kSDzgq1E38NSgwgo1dR8vYUjzd1+HmmHfjhTI3XxdTX3+oHwtGYxdtDGjRAxbEPr4CiAEe2ePjmZ5A==}
+  '@repo-toolkit/confluence@0.13.0':
+    resolution: {integrity: sha512-wB2VUS1/ilIsaEcZGXFz8KHdtqaO+6xrI92cEWYfXf8jkK7n2wTLSykhykbs//mHZY5oHpdGrVuYyJkGsRDKtg==}
     engines: {node: '>=20'}
     hasBin: true
 
-  '@repo-toolkit/publish-package@0.9.0':
-    resolution: {integrity: sha512-GXhB+rpuiyJ1Dm64cq1QDANKCh8ruK5aES9pR2KAX82AMPwRlqABGpjLEuHHjbVKPQJ3MxIifttXwE7wPoVhxA==}
+  '@repo-toolkit/publish-package@0.13.0':
+    resolution: {integrity: sha512-0OBO0MwVqy6Gks1pgpRo9MUN+cPhCZT1OQ/0Gm3vdTk8ZMcX3mH5wT6LS+yvAH+41onicxhY6bZkOC+IKduuGg==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -412,8 +418,8 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
-  ansi-regex@6.2.2:
-    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+  ansi-regex@6.3.0:
+    resolution: {integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==}
     engines: {node: '>=12'}
 
   ansi-styles@6.2.3:
@@ -511,16 +517,16 @@ packages:
   confbox@0.2.4:
     resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
 
-  content-type@2.0.0:
-    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
-    engines: {node: '>=18'}
-
-  conventional-changelog-angular@9.2.1:
-    resolution: {integrity: sha512-oWSL6ZhnXbYraOFTK3PgRAQJ8fADDAEv5K6AdeyQPLvjFmhG8+ejL0jZZp/R7vTmGJaBvZEE+sE7dB4bCv7sAw==}
+  content-type@3.0.0:
+    resolution: {integrity: sha512-AIi5H6p0xk5uknXcN3/rmhP8jgp69OfSe/JuKiQAFprJ7UGw7mwj7m4XcmDzlrnJDG+cGpphAINGdU3g3g7kDw==}
     engines: {node: '>=22'}
 
-  conventional-changelog-conventionalcommits@10.2.1:
-    resolution: {integrity: sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==}
+  conventional-changelog-angular@9.4.0:
+    resolution: {integrity: sha512-HdxRxuS8bBXVIuo4V82gvSwAXT0vYQUizrjs/izmPg5JdDstr8v8I5hduGL3iQbG+o310dUDxC4+LetuS5hu9w==}
+    engines: {node: '>=22'}
+
+  conventional-changelog-conventionalcommits@10.4.0:
+    resolution: {integrity: sha512-Rriac6ZrAlVm6cy9Bz4NSp+WMHpwNXoPIYex+HjCgduAVUSbnew29DQjQw0C4g9u3HtSYzGiGY+pdBXAZo+4aA==}
     engines: {node: '>=22'}
 
   conventional-changelog-conventionalcommits@9.3.1:
@@ -596,8 +602,8 @@ packages:
     resolution: {integrity: sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==}
     engines: {node: '>=18'}
 
-  default-browser@5.5.0:
-    resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
+  default-browser@5.5.1:
+    resolution: {integrity: sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==}
     engines: {node: '>=18'}
 
   define-lazy-prop@3.0.0:
@@ -666,8 +672,8 @@ packages:
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
 
-  es-toolkit@1.50.0:
-    resolution: {integrity: sha512-OyZKhUVvEep9ITEiwHn8GKnMRQIVqoSIX7WnRbkWgJkllCujilqP2rD0u979tkl8wqyc8ICwlc1UBVv/Sl1G6w==}
+  es-toolkit@1.51.0:
+    resolution: {integrity: sha512-zC2lQGkM7QX+Gm6iM3+WIdZJzthsEd14LvRNJneSO2hzyz/zNBENR8+YXWo1cKxgPBtV6ksPYHELbcwBRzmdCw==}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -711,8 +717,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.5:
-    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
+  fast-uri@3.1.6:
+    resolution: {integrity: sha512-7Ical1vFEMr0onbVzEDIreM22I4khW+fzyQPwvAFWBp1iwdshSZRsL4jjRvPG9JP1uiqMHRto+YU6R2/CzDz5Q==}
 
   fast-wrap-ansi@0.2.2:
     resolution: {integrity: sha512-7F2Fl+TjRSenLqlU3UjSH0iyqopqoZIu7eZVpEirP2g1GtWa2G/ecEmBdgz31+Mxr+ELclgg6sokpSFIQiZ02Q==}
@@ -802,8 +808,8 @@ packages:
     resolution: {integrity: sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  ip-address@10.4.0:
-    resolution: {integrity: sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==}
+  ip-address@10.5.0:
+    resolution: {integrity: sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==}
     engines: {node: '>= 12'}
 
   is-arrayish@0.2.1:
@@ -887,8 +893,8 @@ packages:
   json-schema-traverse@1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
-  json-with-bigint@3.5.10:
-    resolution: {integrity: sha512-Vcx+JVNEBts/xfcoCS69sKrOhOk/3TVlvlT+XzUOefVKnnrbYSCKpDCm10pohsJFtsJVYnwa/cXRZ4eElzaM6w==}
+  json-with-bigint@3.5.12:
+    resolution: {integrity: sha512-uwbF/wSSuOgC7qqlq27Xp5B6a2MHVug3t0idZdTqu0JnlFvgJuH7ju+KAk/J06C7GfhoYy2gnb9wz2INqcne7w==}
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
@@ -981,8 +987,8 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
-  ohash@2.0.11:
-    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+  ohash@2.0.12:
+    resolution: {integrity: sha512-65S/5gk9YSsaRjcyf7Nfa6h/d3E8/1gslpXfI4W7Dxn/oap8IKRuNT5VXkLQ1YFKIEg4apRY4Pj6aiwFzrDdmw==}
 
   onetime@7.0.0:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
@@ -1091,12 +1097,12 @@ packages:
   rc9@3.0.1:
     resolution: {integrity: sha512-gMDyleLWVE+i6Sgtc0QbbY6pEKqYs97NGi6isHQPqYlLemPoO8dxQ3uGi0f4NiP98c+jMW6cG1Kx9dDwfvqARQ==}
 
-  readdirp@5.0.0:
-    resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
+  readdirp@5.1.1:
+    resolution: {integrity: sha512-Kko+Y5XQ6fM+Ce3dq3m9YGxnacYZYl9cA1wZjaF3Vbry2L3i1qVg8+CAgNPsXRArPMUMCaOR7oa9Nqntc43JKA==}
     engines: {node: '>= 20.19.0'}
 
-  release-it@21.0.1:
-    resolution: {integrity: sha512-xbPuv2tau3gb0Xw0NVqV3QjOhytFvbsBZDqzmURqlwtgNpFIlIbpDbuZG64ptytFOX4H/7k65bbPSLTwAL34/g==}
+  release-it@21.0.2:
+    resolution: {integrity: sha512-QwyDnWiQNB4d8Hc2b5FLMHcsKz9S2O1dMNnPB7w+0knsL5r8+qbnznDA1X7Bw5D863+Ud7eRHc71Cfth5Tlrgg==}
     engines: {node: ^22.21.0 || >=24.0.0}
     hasBin: true
 
@@ -1190,8 +1196,8 @@ packages:
     resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
     engines: {node: '>=12'}
 
-  tinyexec@1.2.4:
-    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.17:
@@ -1305,15 +1311,15 @@ snapshots:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@commitlint/cli@21.2.1(@types/node@25.6.0)(conventional-commits-parser@6.4.0)(typescript@6.0.3)':
+  '@commitlint/cli@21.2.2(@types/node@25.6.0)(conventional-commits-parser@6.4.0)(typescript@6.0.3)':
     dependencies:
-      '@commitlint/config-conventional': 21.2.0
-      '@commitlint/format': 21.2.0
-      '@commitlint/lint': 21.2.0
-      '@commitlint/load': 21.2.0(@types/node@25.6.0)(typescript@6.0.3)
+      '@commitlint/config-conventional': 21.2.2
+      '@commitlint/format': 21.2.2
+      '@commitlint/lint': 21.2.2
+      '@commitlint/load': 21.2.2(@types/node@25.6.0)(typescript@6.0.3)
       '@commitlint/read': 21.2.1(conventional-commits-parser@6.4.0)
       '@commitlint/types': 21.2.0
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
       yargs: 18.1.0
     transitivePeerDependencies:
       - '@types/node'
@@ -1321,10 +1327,10 @@ snapshots:
       - conventional-commits-parser
       - typescript
 
-  '@commitlint/config-conventional@21.2.0':
+  '@commitlint/config-conventional@21.2.2':
     dependencies:
       '@commitlint/types': 21.2.0
-      conventional-changelog-conventionalcommits: 10.2.1
+      conventional-changelog-conventionalcommits: 10.4.0
 
   '@commitlint/config-validator@21.2.0':
     dependencies:
@@ -1334,36 +1340,36 @@ snapshots:
   '@commitlint/ensure@21.2.0':
     dependencies:
       '@commitlint/types': 21.2.0
-      es-toolkit: 1.50.0
+      es-toolkit: 1.51.0
 
   '@commitlint/execute-rule@21.0.1': {}
 
-  '@commitlint/format@21.2.0':
+  '@commitlint/format@21.2.2':
     dependencies:
       '@commitlint/types': 21.2.0
       picocolors: 1.1.1
 
-  '@commitlint/is-ignored@21.2.0':
+  '@commitlint/is-ignored@21.2.2':
     dependencies:
       '@commitlint/types': 21.2.0
       semver: 7.8.5
 
-  '@commitlint/lint@21.2.0':
+  '@commitlint/lint@21.2.2':
     dependencies:
-      '@commitlint/is-ignored': 21.2.0
-      '@commitlint/parse': 21.2.0
-      '@commitlint/rules': 21.2.0
+      '@commitlint/is-ignored': 21.2.2
+      '@commitlint/parse': 21.2.2
+      '@commitlint/rules': 21.2.2
       '@commitlint/types': 21.2.0
 
-  '@commitlint/load@21.2.0(@types/node@25.6.0)(typescript@6.0.3)':
+  '@commitlint/load@21.2.2(@types/node@25.6.0)(typescript@6.0.3)':
     dependencies:
       '@commitlint/config-validator': 21.2.0
       '@commitlint/execute-rule': 21.0.1
-      '@commitlint/resolve-extends': 21.2.0
+      '@commitlint/resolve-extends': 21.2.2
       '@commitlint/types': 21.2.0
       cosmiconfig: 9.0.2(typescript@6.0.3)
       cosmiconfig-typescript-loader: 6.3.0(@types/node@25.6.0)(cosmiconfig@9.0.2(typescript@6.0.3))(typescript@6.0.3)
-      es-toolkit: 1.50.0
+      es-toolkit: 1.51.0
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
     transitivePeerDependencies:
@@ -1372,31 +1378,31 @@ snapshots:
 
   '@commitlint/message@21.2.0': {}
 
-  '@commitlint/parse@21.2.0':
+  '@commitlint/parse@21.2.2':
     dependencies:
       '@commitlint/types': 21.2.0
-      conventional-changelog-angular: 9.2.1
+      conventional-changelog-angular: 9.4.0
       conventional-commits-parser: 7.1.2
 
   '@commitlint/read@21.2.1(conventional-commits-parser@6.4.0)':
     dependencies:
       '@commitlint/top-level': 21.2.0
       '@commitlint/types': 21.2.0
-      '@conventional-changelog/git-client': 3.1.0(conventional-commits-parser@6.4.0)
-      tinyexec: 1.2.4
+      '@conventional-changelog/git-client': 3.1.2(conventional-commits-parser@6.4.0)
+      tinyexec: 1.3.0
     transitivePeerDependencies:
       - conventional-commits-filter
       - conventional-commits-parser
 
-  '@commitlint/resolve-extends@21.2.0':
+  '@commitlint/resolve-extends@21.2.2':
     dependencies:
       '@commitlint/config-validator': 21.2.0
       '@commitlint/types': 21.2.0
-      es-toolkit: 1.50.0
+      es-toolkit: 1.51.0
       global-directory: 5.0.0
       resolve-from: 5.0.0
 
-  '@commitlint/rules@21.2.0':
+  '@commitlint/rules@21.2.2':
     dependencies:
       '@commitlint/ensure': 21.2.0
       '@commitlint/message': 21.2.0
@@ -1422,7 +1428,7 @@ snapshots:
     optionalDependencies:
       conventional-commits-parser: 6.4.0
 
-  '@conventional-changelog/git-client@3.1.0(conventional-commits-parser@6.4.0)':
+  '@conventional-changelog/git-client@3.1.2(conventional-commits-parser@6.4.0)':
     dependencies:
       '@simple-libs/child-process-utils': 2.0.0
       '@simple-libs/stream-utils': 2.0.0
@@ -1430,7 +1436,7 @@ snapshots:
     optionalDependencies:
       conventional-commits-parser: 6.4.0
 
-  '@conventional-changelog/template@1.2.1': {}
+  '@conventional-changelog/template@1.4.0': {}
 
   '@decimalturn/toml-patch@2.1.0': {}
 
@@ -1438,26 +1444,26 @@ snapshots:
 
   '@inquirer/ansi@2.0.7': {}
 
-  '@inquirer/checkbox@5.2.1(@types/node@25.6.0)':
+  '@inquirer/checkbox@5.2.2(@types/node@25.6.0)':
     dependencies:
       '@inquirer/ansi': 2.0.7
-      '@inquirer/core': 11.2.1(@types/node@25.6.0)
-      '@inquirer/figures': 2.0.7
+      '@inquirer/core': 12.0.0(@types/node@25.6.0)
+      '@inquirer/figures': 2.0.8
       '@inquirer/type': 4.0.7(@types/node@25.6.0)
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/confirm@6.1.1(@types/node@25.6.0)':
+  '@inquirer/confirm@6.2.0(@types/node@25.6.0)':
     dependencies:
-      '@inquirer/core': 11.2.1(@types/node@25.6.0)
+      '@inquirer/core': 12.0.0(@types/node@25.6.0)
       '@inquirer/type': 4.0.7(@types/node@25.6.0)
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/core@11.2.1(@types/node@25.6.0)':
+  '@inquirer/core@12.0.0(@types/node@25.6.0)':
     dependencies:
       '@inquirer/ansi': 2.0.7
-      '@inquirer/figures': 2.0.7
+      '@inquirer/figures': 2.0.8
       '@inquirer/type': 4.0.7(@types/node@25.6.0)
       cli-width: 4.1.0
       fast-wrap-ansi: 0.2.2
@@ -1466,87 +1472,87 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/editor@5.2.2(@types/node@25.6.0)':
+  '@inquirer/editor@5.3.0(@types/node@25.6.0)':
     dependencies:
-      '@inquirer/core': 11.2.1(@types/node@25.6.0)
-      '@inquirer/external-editor': 3.0.3(@types/node@25.6.0)
+      '@inquirer/core': 12.0.0(@types/node@25.6.0)
+      '@inquirer/external-editor': 3.0.4(@types/node@25.6.0)
       '@inquirer/type': 4.0.7(@types/node@25.6.0)
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/expand@5.1.1(@types/node@25.6.0)':
+  '@inquirer/expand@5.1.2(@types/node@25.6.0)':
     dependencies:
-      '@inquirer/core': 11.2.1(@types/node@25.6.0)
+      '@inquirer/core': 12.0.0(@types/node@25.6.0)
       '@inquirer/type': 4.0.7(@types/node@25.6.0)
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/external-editor@3.0.3(@types/node@25.6.0)':
+  '@inquirer/external-editor@3.0.4(@types/node@25.6.0)':
     dependencies:
       chardet: 2.2.0
       iconv-lite: 0.7.3
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/figures@2.0.7': {}
+  '@inquirer/figures@2.0.8': {}
 
-  '@inquirer/input@5.1.2(@types/node@25.6.0)':
+  '@inquirer/input@5.1.3(@types/node@25.6.0)':
     dependencies:
-      '@inquirer/core': 11.2.1(@types/node@25.6.0)
+      '@inquirer/core': 12.0.0(@types/node@25.6.0)
       '@inquirer/type': 4.0.7(@types/node@25.6.0)
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/number@4.1.1(@types/node@25.6.0)':
+  '@inquirer/number@4.2.0(@types/node@25.6.0)':
     dependencies:
-      '@inquirer/core': 11.2.1(@types/node@25.6.0)
+      '@inquirer/core': 12.0.0(@types/node@25.6.0)
       '@inquirer/type': 4.0.7(@types/node@25.6.0)
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/password@5.1.1(@types/node@25.6.0)':
+  '@inquirer/password@5.1.2(@types/node@25.6.0)':
     dependencies:
       '@inquirer/ansi': 2.0.7
-      '@inquirer/core': 11.2.1(@types/node@25.6.0)
+      '@inquirer/core': 12.0.0(@types/node@25.6.0)
       '@inquirer/type': 4.0.7(@types/node@25.6.0)
     optionalDependencies:
       '@types/node': 25.6.0
 
   '@inquirer/prompts@8.5.2(@types/node@25.6.0)':
     dependencies:
-      '@inquirer/checkbox': 5.2.1(@types/node@25.6.0)
-      '@inquirer/confirm': 6.1.1(@types/node@25.6.0)
-      '@inquirer/editor': 5.2.2(@types/node@25.6.0)
-      '@inquirer/expand': 5.1.1(@types/node@25.6.0)
-      '@inquirer/input': 5.1.2(@types/node@25.6.0)
-      '@inquirer/number': 4.1.1(@types/node@25.6.0)
-      '@inquirer/password': 5.1.1(@types/node@25.6.0)
-      '@inquirer/rawlist': 5.3.1(@types/node@25.6.0)
-      '@inquirer/search': 4.2.1(@types/node@25.6.0)
-      '@inquirer/select': 5.2.1(@types/node@25.6.0)
+      '@inquirer/checkbox': 5.2.2(@types/node@25.6.0)
+      '@inquirer/confirm': 6.2.0(@types/node@25.6.0)
+      '@inquirer/editor': 5.3.0(@types/node@25.6.0)
+      '@inquirer/expand': 5.1.2(@types/node@25.6.0)
+      '@inquirer/input': 5.1.3(@types/node@25.6.0)
+      '@inquirer/number': 4.2.0(@types/node@25.6.0)
+      '@inquirer/password': 5.1.2(@types/node@25.6.0)
+      '@inquirer/rawlist': 5.3.2(@types/node@25.6.0)
+      '@inquirer/search': 4.3.0(@types/node@25.6.0)
+      '@inquirer/select': 5.2.2(@types/node@25.6.0)
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/rawlist@5.3.1(@types/node@25.6.0)':
+  '@inquirer/rawlist@5.3.2(@types/node@25.6.0)':
     dependencies:
-      '@inquirer/core': 11.2.1(@types/node@25.6.0)
+      '@inquirer/core': 12.0.0(@types/node@25.6.0)
       '@inquirer/type': 4.0.7(@types/node@25.6.0)
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/search@4.2.1(@types/node@25.6.0)':
+  '@inquirer/search@4.3.0(@types/node@25.6.0)':
     dependencies:
-      '@inquirer/core': 11.2.1(@types/node@25.6.0)
-      '@inquirer/figures': 2.0.7
+      '@inquirer/core': 12.0.0(@types/node@25.6.0)
+      '@inquirer/figures': 2.0.8
       '@inquirer/type': 4.0.7(@types/node@25.6.0)
     optionalDependencies:
       '@types/node': 25.6.0
 
-  '@inquirer/select@5.2.1(@types/node@25.6.0)':
+  '@inquirer/select@5.2.2(@types/node@25.6.0)':
     dependencies:
       '@inquirer/ansi': 2.0.7
-      '@inquirer/core': 11.2.1(@types/node@25.6.0)
-      '@inquirer/figures': 2.0.7
+      '@inquirer/core': 12.0.0(@types/node@25.6.0)
+      '@inquirer/figures': 2.0.8
       '@inquirer/type': 4.0.7(@types/node@25.6.0)
     optionalDependencies:
       '@types/node': 25.6.0
@@ -1569,70 +1575,76 @@ snapshots:
 
   '@octokit/auth-token@6.0.0': {}
 
-  '@octokit/core@7.0.6':
+  '@octokit/core@7.0.7':
     dependencies:
       '@octokit/auth-token': 6.0.0
-      '@octokit/graphql': 9.0.3
-      '@octokit/request': 10.0.11
-      '@octokit/request-error': 7.1.0
-      '@octokit/types': 16.0.0
+      '@octokit/graphql': 9.0.4
+      '@octokit/request': 10.0.15
+      '@octokit/request-error': 7.1.1
+      '@octokit/types': 17.0.0
       before-after-hook: 4.0.0
       universal-user-agent: 7.0.3
 
-  '@octokit/endpoint@11.0.3':
+  '@octokit/endpoint@11.0.4':
     dependencies:
-      '@octokit/types': 16.0.0
+      '@octokit/types': 17.0.0
       universal-user-agent: 7.0.3
 
-  '@octokit/graphql@9.0.3':
+  '@octokit/graphql@9.0.4':
     dependencies:
-      '@octokit/request': 10.0.11
-      '@octokit/types': 16.0.0
+      '@octokit/request': 10.0.15
+      '@octokit/types': 17.0.0
       universal-user-agent: 7.0.3
 
   '@octokit/openapi-types@27.0.0': {}
 
-  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.6)':
+  '@octokit/openapi-types@28.0.0': {}
+
+  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@7.0.7)':
     dependencies:
-      '@octokit/core': 7.0.6
+      '@octokit/core': 7.0.7
       '@octokit/types': 16.0.0
 
-  '@octokit/plugin-request-log@6.0.0(@octokit/core@7.0.6)':
+  '@octokit/plugin-request-log@6.0.0(@octokit/core@7.0.7)':
     dependencies:
-      '@octokit/core': 7.0.6
+      '@octokit/core': 7.0.7
 
-  '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.6)':
+  '@octokit/plugin-rest-endpoint-methods@17.0.0(@octokit/core@7.0.7)':
     dependencies:
-      '@octokit/core': 7.0.6
+      '@octokit/core': 7.0.7
       '@octokit/types': 16.0.0
 
-  '@octokit/request-error@7.1.0':
+  '@octokit/request-error@7.1.1':
     dependencies:
-      '@octokit/types': 16.0.0
+      '@octokit/types': 17.0.0
 
-  '@octokit/request@10.0.11':
+  '@octokit/request@10.0.15':
     dependencies:
-      '@octokit/endpoint': 11.0.3
-      '@octokit/request-error': 7.1.0
-      '@octokit/types': 16.0.0
-      content-type: 2.0.0
-      json-with-bigint: 3.5.10
+      '@octokit/endpoint': 11.0.4
+      '@octokit/request-error': 7.1.1
+      '@octokit/types': 17.0.0
+      content-type: 3.0.0
+      json-with-bigint: 3.5.12
       universal-user-agent: 7.0.3
 
   '@octokit/rest@22.0.1':
     dependencies:
-      '@octokit/core': 7.0.6
-      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.6)
-      '@octokit/plugin-request-log': 6.0.0(@octokit/core@7.0.6)
-      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.6)
+      '@octokit/core': 7.0.7
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@7.0.7)
+      '@octokit/plugin-request-log': 6.0.0(@octokit/core@7.0.7)
+      '@octokit/plugin-rest-endpoint-methods': 17.0.0(@octokit/core@7.0.7)
 
   '@octokit/types@16.0.0':
     dependencies:
       '@octokit/openapi-types': 27.0.0
 
+  '@octokit/types@17.0.0':
+    dependencies:
+      '@octokit/openapi-types': 28.0.0
+
   '@phun-ky/typeof@2.0.3': {}
 
-  '@release-it/bumper@8.0.0(release-it@21.0.1(@types/node@25.6.0))':
+  '@release-it/bumper@8.0.0(release-it@21.0.2(@types/node@25.6.0))':
     dependencies:
       '@decimalturn/toml-patch': 2.1.0
       '@iarna/toml': 3.0.0
@@ -1642,22 +1654,22 @@ snapshots:
       ini: 6.0.0
       js-yaml: 5.2.2
       lodash-es: 4.18.1
-      release-it: 21.0.1(@types/node@25.6.0)
+      release-it: 21.0.2(@types/node@25.6.0)
       semver: 7.8.5
 
-  '@repo-toolkit/changelog@0.9.0':
+  '@repo-toolkit/changelog@0.13.0':
     dependencies:
-      '@repo-toolkit/publish-package': 0.9.0
+      '@repo-toolkit/publish-package': 0.13.0
       conventional-changelog: 7.2.1
       conventional-changelog-conventionalcommits: 9.3.1
     transitivePeerDependencies:
       - conventional-commits-filter
 
-  '@repo-toolkit/confluence@0.9.0':
+  '@repo-toolkit/confluence@0.13.0':
     dependencies:
-      '@repo-toolkit/publish-package': 0.9.0
+      '@repo-toolkit/publish-package': 0.13.0
 
-  '@repo-toolkit/publish-package@0.9.0':
+  '@repo-toolkit/publish-package@0.13.0':
     dependencies:
       '@clack/prompts': 1.7.0
 
@@ -1690,11 +1702,11 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.5
+      fast-uri: 3.1.6
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  ansi-regex@6.2.2: {}
+  ansi-regex@6.3.0: {}
 
   ansi-styles@6.2.3: {}
 
@@ -1735,7 +1747,7 @@ snapshots:
       exsolve: 1.1.1
       giget: 3.3.1
       jiti: 2.7.0
-      ohash: 2.0.11
+      ohash: 2.0.12
       pathe: 2.0.3
       perfect-debounce: 2.1.0
       pkg-types: 2.3.1
@@ -1772,7 +1784,7 @@ snapshots:
 
   chokidar@5.0.0:
     dependencies:
-      readdirp: 5.0.0
+      readdirp: 5.1.1
 
   ci-info@4.4.0: {}
 
@@ -1797,15 +1809,15 @@ snapshots:
 
   confbox@0.2.4: {}
 
-  content-type@2.0.0: {}
+  content-type@3.0.0: {}
 
-  conventional-changelog-angular@9.2.1:
+  conventional-changelog-angular@9.4.0:
     dependencies:
-      '@conventional-changelog/template': 1.2.1
+      '@conventional-changelog/template': 1.4.0
 
-  conventional-changelog-conventionalcommits@10.2.1:
+  conventional-changelog-conventionalcommits@10.4.0:
     dependencies:
-      '@conventional-changelog/template': 1.2.1
+      '@conventional-changelog/template': 1.4.0
 
   conventional-changelog-conventionalcommits@9.3.1:
     dependencies:
@@ -1881,7 +1893,7 @@ snapshots:
 
   default-browser-id@5.0.1: {}
 
-  default-browser@5.5.0:
+  default-browser@5.5.1:
     dependencies:
       bundle-name: 4.1.0
       default-browser-id: 5.0.1
@@ -1944,7 +1956,7 @@ snapshots:
     dependencies:
       is-arrayish: 0.2.1
 
-  es-toolkit@1.50.0: {}
+  es-toolkit@1.51.0: {}
 
   escalade@3.2.0: {}
 
@@ -1982,7 +1994,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.5: {}
+  fast-uri@3.1.6: {}
 
   fast-wrap-ansi@0.2.2:
     dependencies:
@@ -2088,7 +2100,7 @@ snapshots:
 
   ini@6.0.0: {}
 
-  ip-address@10.4.0: {}
+  ip-address@10.5.0: {}
 
   is-arrayish@0.2.1: {}
 
@@ -2150,7 +2162,7 @@ snapshots:
 
   json-schema-traverse@1.0.0: {}
 
-  json-with-bigint@3.5.10: {}
+  json-with-bigint@3.5.12: {}
 
   lines-and-columns@1.2.4: {}
 
@@ -2220,7 +2232,7 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  ohash@2.0.11: {}
+  ohash@2.0.12: {}
 
   onetime@7.0.0:
     dependencies:
@@ -2228,7 +2240,7 @@ snapshots:
 
   open@11.0.0:
     dependencies:
-      default-browser: 5.5.0
+      default-browser: 5.5.1
       define-lazy-prop: 3.0.0
       is-in-ssh: 1.0.0
       is-inside-container: 1.0.0
@@ -2353,9 +2365,9 @@ snapshots:
       defu: 6.1.7
       destr: 2.0.5
 
-  readdirp@5.0.0: {}
+  readdirp@5.1.1: {}
 
-  release-it@21.0.1(@types/node@25.6.0):
+  release-it@21.0.2(@types/node@25.6.0):
     dependencies:
       '@inquirer/prompts': 8.5.2(@types/node@25.6.0)
       '@octokit/rest': 22.0.1
@@ -2426,7 +2438,7 @@ snapshots:
 
   socks@2.8.9:
     dependencies:
-      ip-address: 10.4.0
+      ip-address: 10.5.0
       smart-buffer: 4.2.0
 
   source-map@0.6.1: {}
@@ -2460,9 +2472,9 @@ snapshots:
 
   strip-ansi@7.2.0:
     dependencies:
-      ansi-regex: 6.2.2
+      ansi-regex: 6.3.0
 
-  tinyexec@1.2.4: {}
+  tinyexec@1.3.0: {}
 
   tinyglobby@0.2.17:
     dependencies:


### PR DESCRIPTION
## Summary
Introduce a new gated publication mode for the Docker build/push composite action, along with optional registry login control and expanded outputs for verification and artifact reporting.

## What changed
- Added `publish-mode` with `direct` and `gated` behavior.
- Added `registry-login` so callers can skip authentication when using an already-authenticated client or local registry.
- Extended the action with gated pre-push checks, local image verification, Trivy gating, and optional SBOM generation.
- Exposed new outputs for the local image reference, config digest, manifest digest, and SBOM path.
- Updated the README to document the new mode, inputs, outputs, and usage patterns.
- Expanded the workflow test coverage with a gated registry scenario.
- Updated local toolchain and package dependencies.

## Details
### Action behavior
- `direct` remains the default and preserves the existing build-and-push flow.
- `gated` builds a local single-platform image, optionally runs trusted pre-push validation, scans with Trivy before publishing, pushes the exact image, and verifies the published config digest.
- Trivy uploads are now optional via `upload-sarif`.
- Metadata annotations and multi-output direct publishing are intentionally rejected in gated mode to preserve image integrity.

### Documentation
The README now explains:
- when to use `direct` vs `gated`
- how to disable registry login
- new inputs and outputs
- the constraints and security considerations for gated publication

### Workflow coverage
The test workflow now includes a gated registry-backed test that validates:
- local image identity capture
- gated outputs
- publication to an alternate registry endpoint
- verification of the pushed image

### Dependency updates
Updated Node.js/pnpm tool versions and refreshed dev dependency ranges plus the lockfile.

## Notes
- The new gated mode is designed for cases where tags must not move until checks pass.
- Callers that rely on GitHub code scanning uploads should continue to grant `security-events: write` when `upload-sarif` is enabled.