### PR TITLE
Add GitHub image attestations support

### DIFF
--- a/.github/workflows/test-docker-build-push.yml
+++ b/.github/workflows/test-docker-build-push.yml
@@ -22,7 +22,10 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-24.04
     permissions:
+      artifact-metadata: write
+      attestations: write
       contents: read
+      id-token: write
       packages: write
 
     env:
@@ -50,7 +53,10 @@ jobs:
           type=raw,value=${{ env.IMAGE_TAG }}
         docker-context: ./tests/fixtures/docker-build-push
         docker-file: ./tests/fixtures/docker-build-push/Dockerfile
-        docker-outputs: type=image,push=true,compression=gzip,force-compression=true
+        publish-mode: gated
+        sbom: 'true'
+        attest-provenance: 'true'
+        attest-sbom: 'true'
 
     - name: Verify action outputs
       shell: bash
@@ -59,9 +65,17 @@ jobs:
         IMAGE_TAG: ${{ env.IMAGE_TAG }}
         DOCKER_TAGS: ${{ steps.build.outputs.docker-tags }}
         METADATA_JSON: ${{ steps.build.outputs.metadata-json }}
+        PROVENANCE_ATTESTATION_ID: ${{ steps.build.outputs.provenance-attestation-id }}
+        PROVENANCE_STORAGE_RECORD_IDS: ${{ steps.build.outputs.provenance-storage-record-ids }}
+        SBOM_ATTESTATION_ID: ${{ steps.build.outputs.sbom-attestation-id }}
+        SBOM_STORAGE_RECORD_IDS: ${{ steps.build.outputs.sbom-storage-record-ids }}
       run: |
         [[ "$DOCKER_TAGS" == *"$FULL_IMAGE:$IMAGE_TAG"* ]]
         [[ -n "$METADATA_JSON" ]]
+        [[ -n "$PROVENANCE_ATTESTATION_ID" ]]
+        [[ -n "$PROVENANCE_STORAGE_RECORD_IDS" ]]
+        [[ -n "$SBOM_ATTESTATION_ID" ]]
+        [[ -n "$SBOM_STORAGE_RECORD_IDS" ]]
 
     - name: Verify image can be pulled from GHCR
       shell: bash
@@ -88,6 +102,29 @@ jobs:
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+    - name: Build and push fixture image in direct mode
+      id: direct
+      uses: ./
+      with:
+        registry-url: ${{ env.TEST_REGISTRY }}
+        registry-login: 'false'
+        image-name: ${{ env.IMAGE_NAME }}
+        metadata-tags: |
+          type=raw,value=direct-${{ env.IMAGE_TAG }}
+        docker-context: ./tests/fixtures/docker-build-push
+        docker-file: ./tests/fixtures/docker-build-push/Dockerfile
+        docker-outputs: type=image,push=true,compression=gzip,force-compression=true
+
+    - name: Verify direct mode through compatibility wrapper
+      env:
+        DIRECT_REF: ${{ env.TEST_REGISTRY }}/${{ env.IMAGE_NAME }}:direct-${{ env.IMAGE_TAG }}
+        MANIFEST_DIGEST: ${{ steps.direct.outputs.manifest-digest }}
+      run: |
+        set -euo pipefail
+        [[ "$MANIFEST_DIGEST" == sha256:* ]]
+        docker pull "$DIRECT_REF"
+      shell: bash
 
     - name: Build, check, and push fixture image
       id: build

--- a/.github/workflows/test-docker-build-push.yml
+++ b/.github/workflows/test-docker-build-push.yml
@@ -98,7 +98,7 @@ jobs:
     env:
       IMAGE_NAME: actions/docker-build-push-test
       IMAGE_TAG: test-${{ github.run_id }}
-      TEST_REGISTRY: localhost:5000
+      TEST_REGISTRY: 127.0.0.1:5000
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1

--- a/action.yml
+++ b/action.yml
@@ -77,6 +77,22 @@ inputs:
     description: Path for the generated SPDX JSON SBOM
     required: false
     default: image-sbom.spdx.json
+  attest-provenance:
+    description: Create a GitHub build provenance attestation for the verified image
+    required: false
+    default: 'false'
+  attest-sbom:
+    description: Create a GitHub SBOM attestation for the verified image
+    required: false
+    default: 'false'
+  attest-push-to-registry:
+    description: Push enabled attestations to the OCI registry
+    required: false
+    default: 'true'
+  attest-create-storage-record:
+    description: Create a GitHub artifact metadata storage record for enabled attestations
+    required: false
+    default: 'true'
 
 outputs:
   docker-version:
@@ -118,6 +134,30 @@ outputs:
   sbom-path:
     description: Path to the generated image SBOM when enabled
     value: ${{ steps.delegate.outputs.sbom-path }}
+  provenance-attestation-id:
+    description: GitHub ID of the generated provenance attestation
+    value: ${{ steps.delegate.outputs.provenance-attestation-id }}
+  provenance-attestation-url:
+    description: GitHub URL of the generated provenance attestation
+    value: ${{ steps.delegate.outputs.provenance-attestation-url }}
+  provenance-bundle-path:
+    description: Path to the generated provenance attestation bundle
+    value: ${{ steps.delegate.outputs.provenance-bundle-path }}
+  provenance-storage-record-ids:
+    description: GitHub artifact metadata storage record IDs for the provenance attestation
+    value: ${{ steps.delegate.outputs.provenance-storage-record-ids }}
+  sbom-attestation-id:
+    description: GitHub ID of the generated SBOM attestation
+    value: ${{ steps.delegate.outputs.sbom-attestation-id }}
+  sbom-attestation-url:
+    description: GitHub URL of the generated SBOM attestation
+    value: ${{ steps.delegate.outputs.sbom-attestation-url }}
+  sbom-bundle-path:
+    description: Path to the generated SBOM attestation bundle
+    value: ${{ steps.delegate.outputs.sbom-bundle-path }}
+  sbom-storage-record-ids:
+    description: GitHub artifact metadata storage record IDs for the SBOM attestation
+    value: ${{ steps.delegate.outputs.sbom-storage-record-ids }}
 
 runs:
   using: composite
@@ -148,3 +188,7 @@ runs:
       upload-sarif: ${{ inputs.upload-sarif }}
       sbom: ${{ inputs.sbom }}
       sbom-file: ${{ inputs.sbom-file }}
+      attest-provenance: ${{ inputs.attest-provenance }}
+      attest-sbom: ${{ inputs.attest-sbom }}
+      attest-push-to-registry: ${{ inputs.attest-push-to-registry }}
+      attest-create-storage-record: ${{ inputs.attest-create-storage-record }}

--- a/docker-build-push/README.md
+++ b/docker-build-push/README.md
@@ -11,6 +11,7 @@ Builds a Docker image, pushes it to any OCI-compatible registry, and exposes gen
 - Supports the backward-compatible `direct` build-and-push mode.
 - Supports a single-platform `gated` mode that builds locally, runs optional pre-push checks and Trivy, then pushes and verifies the exact local image config digest.
 - Optionally generates an SPDX JSON SBOM and uploads SARIF results to the GitHub Security tab.
+- Optionally creates GitHub provenance and SBOM attestations for the verified image.
 
 ## Usage
 
@@ -89,6 +90,8 @@ Use `gated` mode when registry tags must not change until checks pass:
     pre-push-command: docker run --rm "$IMAGE_REF" myapp --version
     trivy: 'true'
     sbom: 'true'
+    attest-provenance: 'true'
+    attest-sbom: 'true'
 
 - name: Use the verified publication outputs
   run: |
@@ -100,6 +103,15 @@ Use `gated` mode when registry tags must not change until checks pass:
 ```
 
 The registry host is not tied to GHCR. For an already-authenticated Docker client or an unauthenticated local registry, set `registry-login: 'false'` and omit credentials.
+
+GitHub attestations are optional. Callers enabling them must grant `id-token: write` and `attestations: write`. Callers creating artifact storage records must also grant `artifact-metadata: write`:
+
+```yaml
+permissions:
+  artifact-metadata: write
+  attestations: write
+  id-token: write
+```
 
 ### Share Metadata Between Labels And Annotations
 
@@ -146,6 +158,10 @@ The registry host is not tied to GHCR. For an already-authenticated Docker clien
 | `upload-sarif` | No | `"true"` | Upload Trivy SARIF to GitHub code scanning. |
 | `sbom` | No | `"false"` | Generate an SPDX JSON SBOM from the gated local image. |
 | `sbom-file` | No | `image-sbom.spdx.json` | Path for the generated image SBOM. |
+| `attest-provenance` | No | `"false"` | Create GitHub build provenance for the verified image. Requires gated mode. |
+| `attest-sbom` | No | `"false"` | Create a GitHub attestation from the generated SBOM. Requires `sbom: "true"` and gated mode. |
+| `attest-push-to-registry` | No | `"true"` | Attach enabled attestations to the OCI image in the registry. |
+| `attest-create-storage-record` | No | `"true"` | Create GitHub artifact metadata storage records. Requires registry attachment. |
 
 ## Outputs
 
@@ -164,6 +180,14 @@ The registry host is not tied to GHCR. For an already-authenticated Docker clien
 | `image-config-digest` | Config digest of the checked local image in gated mode. |
 | `manifest-digest` | Primary manifest digest reported after publication. |
 | `sbom-path` | Generated image SBOM path when enabled. |
+| `provenance-attestation-id` | GitHub ID of the provenance attestation. |
+| `provenance-attestation-url` | GitHub URL of the provenance attestation. |
+| `provenance-bundle-path` | Local path to the provenance attestation bundle. |
+| `provenance-storage-record-ids` | GitHub artifact metadata storage record IDs for the provenance attestation. |
+| `sbom-attestation-id` | GitHub ID of the SBOM attestation. |
+| `sbom-attestation-url` | GitHub URL of the SBOM attestation. |
+| `sbom-bundle-path` | Local path to the SBOM attestation bundle. |
+| `sbom-storage-record-ids` | GitHub artifact metadata storage record IDs for the SBOM attestation. |
 
 ## Notes
 
@@ -175,4 +199,6 @@ The registry host is not tied to GHCR. For an already-authenticated Docker clien
 - Gated mode authenticates only after the local checks and vulnerability gate pass, pushes each generated tag from the same local image, and verifies every remote manifest config digest against the local config digest.
 - `pre-push-command` is executable code and should only contain trusted workflow configuration. The command receives `IMAGE_REF` and `IMAGE_CONFIG_DIGEST`.
 - The Trivy upload requires `security-events: write`. Set `upload-sarif: 'false'` when that GitHub-specific integration is unavailable or unwanted.
-- Registry-specific signing and attestations remain caller responsibilities. The `manifest-digest` output can be passed to the registry's supported attestation tooling.
+- Attestations use GitHub Artifact Attestations and therefore require GitHub.com plus the documented job permissions. Private and internal repositories require GitHub Enterprise Cloud; GitHub Enterprise Server is not supported.
+- Registry attachment uses the existing Docker login and requires an OCI registry that supports attestation/referrer artifacts. Set `attest-push-to-registry: 'false'` and `attest-create-storage-record: 'false'` to keep attestations in GitHub only when the target registry does not support attachment.
+- Artifact metadata storage records are available only to organization-owned repositories. When requested, the action fails if GitHub does not return a storage record ID; disable `attest-create-storage-record` for user-owned repositories.

--- a/docker-build-push/action.yml
+++ b/docker-build-push/action.yml
@@ -249,6 +249,8 @@ runs:
   - name: Set up Docker Buildx
     # See https://github.com/docker/setup-buildx-action/commits/master/
     uses: docker/setup-buildx-action@21162887f0d6e25b4e8eafb0cf44cf9bf7f6acd3
+    with:
+      driver-opts: network=host
 
   - name: Set Environment variables
     run: |

--- a/docker-build-push/action.yml
+++ b/docker-build-push/action.yml
@@ -77,6 +77,22 @@ inputs:
     description: Path for the generated SPDX JSON SBOM
     required: false
     default: image-sbom.spdx.json
+  attest-provenance:
+    description: Create a GitHub build provenance attestation for the verified image
+    required: false
+    default: 'false'
+  attest-sbom:
+    description: Create a GitHub SBOM attestation for the verified image
+    required: false
+    default: 'false'
+  attest-push-to-registry:
+    description: Push enabled attestations to the OCI registry
+    required: false
+    default: 'true'
+  attest-create-storage-record:
+    description: Create a GitHub artifact metadata storage record for enabled attestations
+    required: false
+    default: 'true'
 
 outputs:
   docker-version:
@@ -118,12 +134,40 @@ outputs:
   sbom-path:
     description: Path to the generated image SBOM when enabled
     value: ${{ steps.sbom-output.outputs.path }}
+  provenance-attestation-id:
+    description: GitHub ID of the generated provenance attestation
+    value: ${{ steps.attest-provenance.outputs.attestation-id }}
+  provenance-attestation-url:
+    description: GitHub URL of the generated provenance attestation
+    value: ${{ steps.attest-provenance.outputs.attestation-url }}
+  provenance-bundle-path:
+    description: Path to the generated provenance attestation bundle
+    value: ${{ steps.attest-provenance.outputs.bundle-path }}
+  provenance-storage-record-ids:
+    description: GitHub artifact metadata storage record IDs for the provenance attestation
+    value: ${{ steps.attest-provenance.outputs.storage-record-ids }}
+  sbom-attestation-id:
+    description: GitHub ID of the generated SBOM attestation
+    value: ${{ steps.attest-sbom.outputs.attestation-id }}
+  sbom-attestation-url:
+    description: GitHub URL of the generated SBOM attestation
+    value: ${{ steps.attest-sbom.outputs.attestation-url }}
+  sbom-bundle-path:
+    description: Path to the generated SBOM attestation bundle
+    value: ${{ steps.attest-sbom.outputs.bundle-path }}
+  sbom-storage-record-ids:
+    description: GitHub artifact metadata storage record IDs for the SBOM attestation
+    value: ${{ steps.attest-sbom.outputs.storage-record-ids }}
 
 runs:
   using: composite
   steps:
   - name: Validate inputs
     env:
+      ATTEST_CREATE_STORAGE_RECORD: ${{ inputs.attest-create-storage-record }}
+      ATTEST_PROVENANCE: ${{ inputs.attest-provenance }}
+      ATTEST_PUSH_TO_REGISTRY: ${{ inputs.attest-push-to-registry }}
+      ATTEST_SBOM: ${{ inputs.attest-sbom }}
       DOCKER_OUTPUTS: ${{ inputs.docker-outputs }}
       METADATA_ANNOTATIONS: ${{ inputs.metadata-annotations }}
       METADATA_LABELS_ANNOTATIONS: ${{ inputs.metadata-labels-annotations }}
@@ -132,6 +176,7 @@ runs:
       REGISTRY_PASSWORD: ${{ inputs.registry-password }}
       REGISTRY_URL: ${{ inputs.registry-url }}
       REGISTRY_USERNAME: ${{ inputs.registry-username }}
+      SBOM: ${{ inputs.sbom }}
     run: |
       set -euo pipefail
 
@@ -143,6 +188,12 @@ runs:
         true|false) ;;
         *) printf 'registry-login must be true or false, got %s\n' "$REGISTRY_LOGIN" >&2; exit 1 ;;
       esac
+      for value in "$ATTEST_PROVENANCE" "$ATTEST_SBOM" "$ATTEST_PUSH_TO_REGISTRY" "$ATTEST_CREATE_STORAGE_RECORD"; do
+        case "$value" in
+          true|false) ;;
+          *) printf 'attestation inputs must be true or false, got %s\n' "$value" >&2; exit 1 ;;
+        esac
+      done
       case "$REGISTRY_URL" in
         ''|*://*|*/) printf 'registry-url must be a registry host without a scheme or trailing slash, got %s\n' "$REGISTRY_URL" >&2; exit 1 ;;
       esac
@@ -156,6 +207,18 @@ runs:
       fi
       if [[ "$PUBLISH_MODE" == gated && ( -n "$METADATA_ANNOTATIONS" || -n "$METADATA_LABELS_ANNOTATIONS" ) ]]; then
         printf 'metadata annotations are not supported in gated mode because Docker image load does not preserve manifest annotations\n' >&2
+        exit 1
+      fi
+      if [[ "$PUBLISH_MODE" != gated && ( "$ATTEST_PROVENANCE" == true || "$ATTEST_SBOM" == true ) ]]; then
+        printf 'image attestations require publish-mode gated so they reference the verified manifest digest\n' >&2
+        exit 1
+      fi
+      if [[ "$ATTEST_SBOM" == true && "$SBOM" != true ]]; then
+        printf 'attest-sbom requires sbom to be true\n' >&2
+        exit 1
+      fi
+      if [[ ( "$ATTEST_PROVENANCE" == true || "$ATTEST_SBOM" == true ) && "$ATTEST_PUSH_TO_REGISTRY" != true && "$ATTEST_CREATE_STORAGE_RECORD" == true ]]; then
+        printf 'attest-create-storage-record requires attest-push-to-registry to be true\n' >&2
         exit 1
       fi
     shell: bash
@@ -377,6 +440,53 @@ runs:
       done <<< "$DOCKER_TAGS"
 
       printf 'manifest-digest=%s\n' "$manifest_digest" >> "$GITHUB_OUTPUT"
+    shell: bash
+
+  - id: attest-provenance
+    name: Attest image provenance
+    if: ${{ inputs.publish-mode == 'gated' && inputs.attest-provenance == 'true' }}
+    # See https://github.com/actions/attest/commits/main/
+    uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d
+    with:
+      subject-name: ${{ inputs.registry-url }}/${{ inputs.image-name }}
+      subject-digest: ${{ steps.publish.outputs.manifest-digest }}
+      subject-version: ${{ steps.meta.outputs.version }}
+      push-to-registry: ${{ inputs.attest-push-to-registry }}
+      create-storage-record: ${{ inputs.attest-create-storage-record }}
+
+  - name: Verify provenance storage record
+    if: ${{ inputs.attest-provenance == 'true' && inputs.attest-create-storage-record == 'true' }}
+    env:
+      STORAGE_RECORD_IDS: ${{ steps.attest-provenance.outputs.storage-record-ids }}
+    run: |
+      if [[ -z "$STORAGE_RECORD_IDS" ]]; then
+        printf 'GitHub did not create the requested provenance artifact storage record\n' >&2
+        exit 1
+      fi
+    shell: bash
+
+  - id: attest-sbom
+    name: Attest image SBOM
+    if: ${{ inputs.publish-mode == 'gated' && inputs.attest-sbom == 'true' }}
+    # See https://github.com/actions/attest/commits/main/
+    uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d
+    with:
+      subject-name: ${{ inputs.registry-url }}/${{ inputs.image-name }}
+      subject-digest: ${{ steps.publish.outputs.manifest-digest }}
+      subject-version: ${{ steps.meta.outputs.version }}
+      sbom-path: ${{ steps.sbom-output.outputs.path }}
+      push-to-registry: ${{ inputs.attest-push-to-registry }}
+      create-storage-record: ${{ inputs.attest-create-storage-record }}
+
+  - name: Verify SBOM storage record
+    if: ${{ inputs.attest-sbom == 'true' && inputs.attest-create-storage-record == 'true' }}
+    env:
+      STORAGE_RECORD_IDS: ${{ steps.attest-sbom.outputs.storage-record-ids }}
+    run: |
+      if [[ -z "$STORAGE_RECORD_IDS" ]]; then
+        printf 'GitHub did not create the requested SBOM artifact storage record\n' >&2
+        exit 1
+      fi
     shell: bash
 
   - name: Run Trivy vulnerability scanner


### PR DESCRIPTION
## Summary

This change adds optional GitHub artifact attestation support to the `docker-build-push` action and updates the test workflow to validate the new behavior. It also adjusts the local test setup so the action can connect to the registry more reliably during Docker Buildx-based tests.

## What changed

### Action inputs and outputs
- Added new inputs to control provenance and SBOM attestations:
  - `attest-provenance`
  - `attest-sbom`
  - `attest-push-to-registry`
  - `attest-create-storage-record`
- Exposed new outputs for attestation IDs, URLs, bundle paths, and storage record IDs.
- Wired the top-level wrapper action through to the underlying composite action.

### Attestation execution
- Added GitHub attestation steps for:
  - provenance attestations
  - SBOM attestations
- Added validation to enforce required combinations:
  - attestations only in `gated` publish mode
  - SBOM attestations require `sbom: true`
  - storage record creation requires registry pushing
- Added checks to fail clearly when requested storage records are not returned.

### Documentation
- Updated the README to describe the new attestation support.
- Documented required GitHub permissions:
  - `id-token: write`
  - `attestations: write`
  - `artifact-metadata: write` when storage records are requested
- Added notes about GitHub.com/GHEC requirements and registry attachment behavior.

### Workflow coverage and test environment
- Updated the test workflow permissions to support attestation generation.
- Expanded the gated-mode test to assert attestation outputs are populated.
- Added a direct-mode compatibility check to ensure the wrapper still works as expected.
- Switched the test registry host from `localhost` to `127.0.0.1` and configured Docker Buildx to use the host network so the test registry is reachable during builds.

## Notes

The new attestation features are opt-in and preserve existing default behavior for callers that do not enable them. The workflow/network updates are limited to the test setup and do not change the public action API.