### PR TITLE
Add asdf fallback for Confluence action CLI resolution

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,6 @@
 nodejs 26.7.0
-python 3.14.6
-pnpm 11.23.0
+python 3.14.7
+pnpm 11.24.0
 act 0.2.89
 actionlint 1.7.12
 shellcheck 0.11.0

--- a/confluence/README.md
+++ b/confluence/README.md
@@ -9,8 +9,8 @@ macros; remote images stay as `<ac:image><ri:url />`.
 
 The action is a thin composite wrapper around the
 [`@repo-toolkit/confluence`](https://github.com/egose/repo-toolkit/tree/main/packages/confluence)
-CLI; install the package in the consuming repository so the action can find it
-in `node_modules/.bin`.
+CLI (`repo-toolkit-confluence` from the [`repo-toolkit`](https://github.com/egose/repo-toolkit) asdf plugin).
+No setup steps are required in the consuming repository — `node` and `repo-toolkit` are auto-installed via `asdf` when missing.
 
 ## What It Does
 
@@ -19,7 +19,7 @@ in `node_modules/.bin`.
 - For each sub-folder path segment, finds or creates a parent page (cached per run by parent id + title).
 - For each Markdown file: converts the body to Confluence storage format, uploads local images as attachments and rewrites the corresponding placeholders, then PUTs the page with `version.number = current + 1` (optimistic concurrency — concurrent writes get HTTP 409).
 - Skips pages whose body is unchanged when `skip-unchanged` is `true` (default).
-- Reuses existing `node` and `pnpm`, or installs missing dependencies automatically via `asdf`.
+- Reuses existing `node`/`pnpm`/`repo-toolkit`, or installs missing runtimes automatically via `asdf`.
 
 ## Usage
 
@@ -39,9 +39,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
       - name: Sync Docs to Confluence
         uses: egose/actions/confluence@main
         with:
@@ -53,7 +50,7 @@ jobs:
           parent-page-id: '123456789'
 ```
 
-If `node`/`pnpm` are already on PATH (e.g. installed by `actions/setup-node`/`pnpm/action-setup` in a previous step, or from the runner image), the action reuses them. Otherwise it installs them via `asdf` automatically — no extra setup steps required.
+Zero setup required — just `actions/checkout` + `uses: egose/actions/confluence@main`. If `node`/`pnpm`/`repo-toolkit` are already on `PATH` (e.g. installed by `actions/setup-node`/`pnpm/action-setup` in a previous step, or from the runner image), the action reuses them. Otherwise it installs them via `asdf` automatically — no extra setup steps required. For fastest startup in JS monorepos, you can still `pnpm add -D @repo-toolkit/confluence && pnpm install` beforehand to reuse `node_modules/.bin`.
 
 ### Dry-run Planning
 
@@ -76,6 +73,7 @@ touching Confluence:
     asdf-version: 'v0.20.0'
     nodejs-version: '26.5.0'
     pnpm-version: '11.15.0'
+    repo-toolkit-version: 'latest' # or '0.13.0'
 ```
 
 ## Inputs
@@ -97,6 +95,8 @@ touching Confluence:
 | `asdf-version` | No | `v0.20.0` | `asdf` version to install when `node` is missing. |
 | `nodejs-version` | No | `26.5.0` | Node.js version to install with `asdf` when `node` is missing. |
 | `pnpm-version` | No | `11.15.0` | pnpm version to install with `asdf` when `pnpm` is missing. |
+| `repo-toolkit-version` | No | `latest` | `repo-toolkit` version to install via `asdf` when binary is not found (`latest` resolves to newest release). |
+| `repo-toolkit-plugin-url` | No | `https://github.com/egose/repo-toolkit.git` | Git URL for the `repo-toolkit` asdf plugin. |
 
 ## Security Notes
 
@@ -107,8 +107,9 @@ touching Confluence:
 ## Notes
 
 - If `node` is missing, the action installs `asdf` first, then Node.js, automatically before resolving the CLI.
-- If `pnpm` is missing, it is installed via `asdf` as well so the consuming repo's `pnpm install` step can run.
-- Existing `node` and `pnpm` installations are reused as-is.
+- If `pnpm` is missing, it is installed via `asdf` as well so the consuming repo's `pnpm install` step can run (optional for `asdf` toolkit path).
+- If `repo-toolkit-confluence` is not found in `node_modules/.bin` or `PATH`, the action installs `repo-toolkit` via `asdf` (`asdf plugin add repo-toolkit https://github.com/egose/repo-toolkit.git && asdf install repo-toolkit <version>`), which requires `node` and `jq`.
+- Existing `node`/`pnpm`/`repo-toolkit` installations are reused as-is.
 - `asdf` install reuses the `asdf-install` action (`../asdf-install/install.sh`); the asdf shims directory is added to `GITHUB_PATH` so subsequent workflow steps also see the installed tools.
 
 ## Binary Resolution
@@ -118,9 +119,9 @@ touching Confluence:
 1. `confluence-bin` input (explicit override).
 2. `<workspace>/node_modules/.bin/repo-toolkit-confluence` (when the consuming repo listed `@repo-toolkit/confluence` as a dep).
 3. `<action_path>/node_modules/.bin/repo-toolkit-confluence` (for repo-internal fixture tests).
-4. `repo-toolkit-confluence` in `PATH`.
-5. `npx -y @repo-toolkit/confluence` (last resort; downloads on every run — not recommended for production).
+4. `repo-toolkit-confluence` in `PATH` (including `asdf` shims).
+5. `asdf install repo-toolkit <version>` (persistent; installs `repo-toolkit` via `asdf` when `node`+`jq` are available — preferred fallback for zero-setup consumers).
+6. `npx -y @repo-toolkit/confluence` (last resort; downloads on every run — not recommended for production).
 
-Add `@repo-toolkit/confluence` to the consuming repo's `devDependencies` (or
-`dependencies`) and run `pnpm install` before invoking the action for the fastest
-startup.
+For fastest startup in JS repos, add `@repo-toolkit/confluence` to the consuming repo's `devDependencies` (or
+`dependencies`) and run `pnpm install` before invoking the action. For zero-setup (only `actions/checkout`), the action auto-provisions via `asdf`.

--- a/confluence/action.yml
+++ b/confluence/action.yml
@@ -47,7 +47,7 @@ inputs:
     required: false
     default: ${{ github.workspace }}
   confluence-bin:
-    description: Path to the repo-toolkit-confluence binary. Leave empty to auto-resolve from node_modules/.bin or npx.
+    description: Path to the repo-toolkit-confluence binary. Leave empty to auto-resolve from node_modules/.bin, asdf shims, or npx.
     required: false
     default: ''
   asdf-version:
@@ -62,6 +62,14 @@ inputs:
     description: pnpm version to install with asdf when pnpm is missing
     required: false
     default: 11.15.0
+  repo-toolkit-version:
+    description: repo-toolkit version to install via asdf when binary is not found. Use 'latest' for newest release.
+    required: false
+    default: latest
+  repo-toolkit-plugin-url:
+    description: Git URL for the repo-toolkit asdf plugin
+    required: false
+    default: https://github.com/egose/repo-toolkit.git
 
 runs:
   using: composite
@@ -86,3 +94,5 @@ runs:
       CONFLUENCE_ASDF_VERSION: ${{ inputs.asdf-version }}
       CONFLUENCE_NODEJS_VERSION: ${{ inputs.nodejs-version }}
       CONFLUENCE_PNPM_VERSION: ${{ inputs.pnpm-version }}
+      CONFLUENCE_REPO_TOOLKIT_VERSION: ${{ inputs.repo-toolkit-version }}
+      CONFLUENCE_REPO_TOOLKIT_PLUGIN_URL: ${{ inputs.repo-toolkit-plugin-url }}

--- a/confluence/run.sh
+++ b/confluence/run.sh
@@ -44,6 +44,93 @@ join_args() {
   echo "$out"
 }
 
+ensure_asdf_available() {
+  if command -v asdf >/dev/null 2>&1; then
+    return 0
+  fi
+  echo "➡️ Installing asdf ${CONFLUENCE_ASDF_VERSION:-v0.20.0} for repo-toolkit..."
+  ASDF_VERSION="${CONFLUENCE_ASDF_VERSION:-v0.20.0}" bash "${CONFLUENCE_ACTION_PATH:?}/../asdf-install/install.sh"
+  export PATH="${RUNNER_TEMP:-/tmp}/asdf-bin:${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
+  if ! command -v asdf >/dev/null 2>&1; then
+    echo >&2 "❌ asdf is unavailable after bootstrap"
+    return 1
+  fi
+}
+
+install_repo_toolkit_via_asdf() {
+  # Already resolved via PATH - nothing to do
+  if command -v repo-toolkit-confluence >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo >&2 "⚠️  jq not found; cannot install repo-toolkit via asdf (requires jq for GitHub release lookup)."
+    return 1
+  fi
+
+  if ! command -v node >/dev/null 2>&1; then
+    echo >&2 "⚠️  node not found; cannot install repo-toolkit via asdf."
+    return 1
+  fi
+
+  ensure_asdf_available || return 1
+
+  local toolkit_version="${CONFLUENCE_REPO_TOOLKIT_VERSION:-latest}"
+  local toolkit_plugin_url="${CONFLUENCE_REPO_TOOLKIT_PLUGIN_URL:-https://github.com/egose/repo-toolkit.git}"
+
+  echo >&2 "➡️  repo-toolkit-confluence not found; installing repo-toolkit ${toolkit_version} via asdf..."
+
+  # Add plugin if not already present
+  if ! asdf plugin list 2>/dev/null | grep -q "^repo-toolkit$"; then
+    asdf plugin add repo-toolkit "$toolkit_plugin_url" || true
+  fi
+
+  if ! asdf install repo-toolkit "$toolkit_version"; then
+    echo >&2 "⚠️  asdf repo-toolkit install failed for version ${toolkit_version}"
+    return 1
+  fi
+
+  # Resolve 'latest' to concrete version for shim compatibility
+  local actual_version="$toolkit_version"
+  if [[ "$actual_version" == "latest" ]]; then
+    actual_version=$(asdf latest repo-toolkit 2>/dev/null || asdf list repo-toolkit 2>/dev/null | tr -s ' ' '\n' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' | tail -n1)
+    # fallback: list installs directory
+    if [[ -z "$actual_version" || "$actual_version" == "latest" ]]; then
+      actual_version=$(ls "${ASDF_DATA_DIR:-$HOME/.asdf}/installs/repo-toolkit" 2>/dev/null | sort -V | tail -n1)
+    fi
+  fi
+  if [[ -n "$actual_version" && "$actual_version" != "latest" ]]; then
+    # Ensure shim resolves without .tool-versions in consumer repo
+    asdf global repo-toolkit "$actual_version" 2>/dev/null || true
+  fi
+
+  local shims_dir="${ASDF_DATA_DIR:-$HOME/.asdf}/shims"
+  echo "$shims_dir" >> "$GITHUB_PATH" 2>/dev/null || true
+  export PATH="$shims_dir:$PATH"
+  asdf reshim repo-toolkit 2>/dev/null || asdf reshim 2>/dev/null || true
+
+  # Prefer shim, but also try direct install path (bypasses .tool-versions requirement)
+  if command -v repo-toolkit-confluence >/dev/null 2>&1; then
+    echo >&2 "✅ repo-toolkit ${actual_version:-$toolkit_version} installed via asdf"
+    return 0
+  fi
+  if [[ -n "$actual_version" ]]; then
+    local direct_bin="${ASDF_DATA_DIR:-$HOME/.asdf}/installs/repo-toolkit/${actual_version}/bin/repo-toolkit-confluence"
+    if [[ -x "$direct_bin" ]]; then
+      echo >&2 "✅ repo-toolkit ${actual_version} installed via asdf (direct bin)"
+      # symlink into shims dir for PATH lookup
+      ln -sf "$direct_bin" "$shims_dir/repo-toolkit-confluence" 2>/dev/null || true
+      export PATH="$shims_dir:$PATH"
+      if command -v repo-toolkit-confluence >/dev/null 2>&1; then
+        return 0
+      fi
+    fi
+  fi
+
+  echo >&2 "⚠️  repo-toolkit-confluence still not found after asdf install"
+  return 1
+}
+
 resolve_binary() {
   # 1. Explicit override
   if [[ -n "${CONFLUENCE_INPUT_BIN:-}" ]]; then
@@ -69,22 +156,32 @@ resolve_binary() {
     return 0
   fi
 
-  # 4. PATH lookup
+  # 4. PATH lookup (includes asdf shims)
   if command -v repo-toolkit-confluence >/dev/null 2>&1; then
     echo "repo-toolkit-confluence"
     return 0
   fi
 
-  # 5. npx fallback (downloads on demand; warn loudly)
+  # 5. asdf repo-toolkit fallback (persistent, preferred over npx)
+  if install_repo_toolkit_via_asdf; then
+    if command -v repo-toolkit-confluence >/dev/null 2>&1; then
+      echo "repo-toolkit-confluence"
+      return 0
+    fi
+  fi
+
+  # 6. npx fallback (downloads on demand; warn loudly)
   echo >&2 "‼️  repo-toolkit-confluence not found; falling back to npx (will download on every run)."
-  echo >&2 "   Install it in the consuming repo (pnpm add -D @repo-toolkit/confluence) for better performance."
+  echo >&2 "   Install it in the consuming repo (pnpm add -D @repo-toolkit/confluence) or pin repo-toolkit-version for better performance."
   echo "npx -y @repo-toolkit/confluence"
 }
 
 # Bootstrap node + pnpm via asdf when either is missing on PATH. Mirrors the
 # pattern used by pre-commit/run.sh: reuse existing installations as-is, only
 # install when the command is unavailable. Adds the asdf shims to GITHUB_PATH
-# so subsequent workflow steps also see node/pnpm.
+# so subsequent workflow steps also see node/pnpm. For the zero-setup path
+# (consumer with only actions/checkout), node is required but pnpm is
+# best-effort - repo-toolkit via asdf works without pnpm.
 ensure_runtimes() {
   local node_ok=false pnpm_ok=false
   command -v node  >/dev/null 2>&1 && node_ok=true
@@ -95,14 +192,7 @@ ensure_runtimes() {
     return 0
   fi
 
-  echo "➡️ Installing asdf ${CONFLUENCE_ASDF_VERSION:-v0.20.0}..."
-  ASDF_VERSION="${CONFLUENCE_ASDF_VERSION:-v0.20.0}" bash "${CONFLUENCE_ACTION_PATH:?}/../asdf-install/install.sh"
-  export PATH="${RUNNER_TEMP:-/tmp}/asdf-bin:${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
-
-  if ! command -v asdf >/dev/null 2>&1; then
-    echo >&2 "❌ asdf is unavailable after bootstrap"
-    exit 1
-  fi
+  ensure_asdf_available || exit 1
 
   if [[ "$node_ok" != "true" ]]; then
     echo "➡️ Installing nodejs ${CONFLUENCE_NODEJS_VERSION:-26.5.0} via asdf..."
@@ -117,7 +207,7 @@ ensure_runtimes() {
   fi
 
   local shims_dir="${ASDF_DATA_DIR:-$HOME/.asdf}/shims"
-  echo "$shims_dir" >> "$GITHUB_PATH"
+  echo "$shims_dir" >> "$GITHUB_PATH" 2>/dev/null || true
   export PATH="$shims_dir:$PATH"
 
   if ! command -v node >/dev/null 2>&1; then
@@ -125,8 +215,7 @@ ensure_runtimes() {
     exit 1
   fi
   if ! command -v pnpm >/dev/null 2>&1; then
-    echo >&2 "❌ pnpm is unavailable after dependency bootstrap"
-    exit 1
+    echo >&2 "⚠️  pnpm is unavailable after dependency bootstrap (continuing; repo-toolkit via asdf does not require pnpm)"
   fi
 }
 
@@ -136,9 +225,9 @@ main() {
     exit 1
   fi
 
-  # Make sure node + pnpm are available before resolving the CLI (every
-  # bin-resolution path ultimately execs node; the pnpm shim is also needed
-  # to install @repo-toolkit/confluence into the consuming repo).
+  # Make sure node (and optionally pnpm) are available before resolving the CLI.
+  # For zero-setup consumers, repo-toolkit is auto-installed via asdf when
+  # node_modules/.bin is missing.
   ensure_runtimes
 
   # Resolve the binary BEFORE cd-ing to $cwd so that the workspace-level


### PR DESCRIPTION
## Summary

This change set makes the Confluence action usable with zero setup in consuming repositories by adding an `asdf`-based fallback for `repo-toolkit-confluence`, while updating the documentation and local tool versions accordingly.

## Changes

### Feature: asdf fallback for CLI resolution
- Adds new action inputs for:
  - `repo-toolkit-version`
  - `repo-toolkit-plugin-url`
- Updates the `confluence-bin` description to include `asdf` shims as a resolution source.
- Extends `run.sh` to:
  - bootstrap `asdf` when needed,
  - install `repo-toolkit` via `asdf` when the CLI is not already available,
  - keep `pnpm` as a best-effort dependency for the `asdf` toolkit path,
  - fall back to `npx` only when the `asdf` route cannot be used.

### Documentation updates
- Revises the README to explain the new zero-setup workflow.
- Documents the new inputs and fallback behavior.
- Updates the binary resolution order and usage examples.
- Removes the now-unnecessary consuming-repo dependency install step from the example workflow.

### Tooling updates
- Bumps `.tool-versions` to the newer local Python and pnpm versions.

## Notes

- Existing `node`, `pnpm`, and `repo-toolkit` installations are still reused when present.
- The `asdf` path is now the preferred persistent fallback before `npx`.
- Consumers can still preinstall `@repo-toolkit/confluence` for the fastest startup in JS repos.