### PR TITLE
Support latest repo-toolkit resolution in Confluence bootstrap

### DIFF
--- a/confluence/run.sh
+++ b/confluence/run.sh
@@ -48,13 +48,31 @@ ensure_asdf_available() {
   if command -v asdf >/dev/null 2>&1; then
     return 0
   fi
-  echo "➡️ Installing asdf ${CONFLUENCE_ASDF_VERSION:-v0.20.0} for repo-toolkit..."
-  ASDF_VERSION="${CONFLUENCE_ASDF_VERSION:-v0.20.0}" bash "${CONFLUENCE_ACTION_PATH:?}/../asdf-install/install.sh"
+  echo >&2 "➡️ Installing asdf ${CONFLUENCE_ASDF_VERSION:-v0.20.0} for repo-toolkit..."
+  ASDF_VERSION="${CONFLUENCE_ASDF_VERSION:-v0.20.0}" bash "${CONFLUENCE_ACTION_PATH:?}/../asdf-install/install.sh" >&2
   export PATH="${RUNNER_TEMP:-/tmp}/asdf-bin:${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
   if ! command -v asdf >/dev/null 2>&1; then
     echo >&2 "❌ asdf is unavailable after bootstrap"
     return 1
   fi
+}
+
+resolve_repo_toolkit_version() {
+  local requested_version="$1"
+
+  if [[ "$requested_version" != "latest" ]]; then
+    echo "$requested_version"
+    return 0
+  fi
+
+  local resolved_version
+  resolved_version="$(asdf list all repo-toolkit 2>/dev/null | grep -E '^[[:space:]]*[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?[[:space:]]*$' | tr -d '[:space:]' | sort -V | tail -n1 || true)"
+  if [[ -z "$resolved_version" ]]; then
+    echo >&2 "⚠️  Unable to resolve the latest repo-toolkit version from asdf"
+    return 1
+  fi
+
+  echo "$resolved_version"
 }
 
 install_repo_toolkit_via_asdf() {
@@ -76,38 +94,36 @@ install_repo_toolkit_via_asdf() {
   ensure_asdf_available || return 1
 
   local toolkit_version="${CONFLUENCE_REPO_TOOLKIT_VERSION:-latest}"
+  local install_version="$toolkit_version"
   local toolkit_plugin_url="${CONFLUENCE_REPO_TOOLKIT_PLUGIN_URL:-https://github.com/egose/repo-toolkit.git}"
-
-  echo >&2 "➡️  repo-toolkit-confluence not found; installing repo-toolkit ${toolkit_version} via asdf..."
 
   # Add plugin if not already present
   if ! asdf plugin list 2>/dev/null | grep -q "^repo-toolkit$"; then
-    asdf plugin add repo-toolkit "$toolkit_plugin_url" || true
+    asdf plugin add repo-toolkit "$toolkit_plugin_url" >&2 || true
   fi
 
-  if ! asdf install repo-toolkit "$toolkit_version"; then
-    echo >&2 "⚠️  asdf repo-toolkit install failed for version ${toolkit_version}"
+  install_version="$(resolve_repo_toolkit_version "$toolkit_version")" || return 1
+  if [[ "$toolkit_version" == "latest" ]]; then
+    echo >&2 "➡️  repo-toolkit-confluence not found; installing repo-toolkit latest via asdf (resolved to ${install_version})..."
+  else
+    echo >&2 "➡️  repo-toolkit-confluence not found; installing repo-toolkit ${install_version} via asdf..."
+  fi
+
+  if ! asdf install repo-toolkit "$install_version" >&2; then
+    echo >&2 "⚠️  asdf repo-toolkit install failed for version ${install_version}"
     return 1
   fi
 
-  # Resolve 'latest' to concrete version for shim compatibility
-  local actual_version="$toolkit_version"
-  if [[ "$actual_version" == "latest" ]]; then
-    actual_version=$(asdf latest repo-toolkit 2>/dev/null || asdf list repo-toolkit 2>/dev/null | tr -s ' ' '\n' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' | tail -n1)
-    # fallback: list installs directory
-    if [[ -z "$actual_version" || "$actual_version" == "latest" ]]; then
-      actual_version=$(ls "${ASDF_DATA_DIR:-$HOME/.asdf}/installs/repo-toolkit" 2>/dev/null | sort -V | tail -n1)
-    fi
-  fi
+  local actual_version="$install_version"
   if [[ -n "$actual_version" && "$actual_version" != "latest" ]]; then
     # Ensure shim resolves without .tool-versions in consumer repo
-    asdf global repo-toolkit "$actual_version" 2>/dev/null || true
+    asdf global repo-toolkit "$actual_version" >&2 || true
   fi
 
   local shims_dir="${ASDF_DATA_DIR:-$HOME/.asdf}/shims"
   echo "$shims_dir" >> "$GITHUB_PATH" 2>/dev/null || true
   export PATH="$shims_dir:$PATH"
-  asdf reshim repo-toolkit 2>/dev/null || asdf reshim 2>/dev/null || true
+  asdf reshim repo-toolkit >&2 || asdf reshim >&2 || true
 
   # Prefer shim, but also try direct install path (bypasses .tool-versions requirement)
   if command -v repo-toolkit-confluence >/dev/null 2>&1; then

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "pre-commit": "pre-commit run --all-files",
     "precommit": "npm run pre-commit",
     "lint": "npm run actionlint && npm run pre-commit",
-    "test:shell": "bash tests/test-install-packages.sh && bash tests/test-release-tag.sh",
+    "test:shell": "bash tests/test-confluence.sh && bash tests/test-install-packages.sh && bash tests/test-release-tag.sh",
     "release": "release-it",
     "changelog": "repo-toolkit-changelog"
   },

--- a/tests/test-confluence.sh
+++ b/tests/test-confluence.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+workspace="$(mktemp -d)"
+bin_dir="${workspace}/bin"
+asdf_data_dir="${workspace}/asdf"
+stdout_file="${workspace}/stdout.log"
+stderr_file="${workspace}/stderr.log"
+asdf_log="${workspace}/asdf.log"
+cli_log="${workspace}/cli.log"
+github_path_file="${workspace}/github.path"
+
+cleanup() {
+  rm -rf "$workspace"
+}
+
+trap cleanup EXIT
+
+mkdir -p "$bin_dir" "${workspace}/docs" "${asdf_data_dir}/shims"
+
+for tool in jq node pnpm; do
+  cat > "${bin_dir}/${tool}" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 0
+EOF
+  chmod 755 "${bin_dir}/${tool}"
+done
+
+cat > "${bin_dir}/asdf" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+log_file="${FAKE_ASDF_LOG:?}"
+asdf_data_dir="${ASDF_DATA_DIR:?}"
+
+case "${1:-}" in
+  plugin)
+    case "${2:-}" in
+      list)
+        exit 0
+        ;;
+      add)
+        printf 'plugin add %s %s\n' "${3:-}" "${4:-}" >> "$log_file"
+        exit 0
+        ;;
+    esac
+    ;;
+  list)
+    if [[ "${2:-}" == "all" && "${3:-}" == "repo-toolkit" ]]; then
+      printf '0.6.0\n0.7.0\n0.14.0\n'
+      exit 0
+    fi
+    if [[ "${2:-}" == "repo-toolkit" ]]; then
+      printf '  0.14.0\n'
+      exit 0
+    fi
+    ;;
+  install)
+    if [[ "${2:-}" == "repo-toolkit" ]]; then
+      printf 'install %s\n' "${3:-}" >> "$log_file"
+      if [[ "${3:-}" != "0.14.0" ]]; then
+        printf 'unexpected repo-toolkit version: %s\n' "${3:-}" >&2
+        exit 1
+      fi
+
+      install_dir="${asdf_data_dir}/installs/repo-toolkit/${3}/bin"
+      mkdir -p "$install_dir"
+      cat > "${install_dir}/repo-toolkit-confluence" <<'CLI'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${FAKE_CLI_LOG:?}"
+CLI
+      chmod 755 "${install_dir}/repo-toolkit-confluence"
+
+      printf 'Downloading repo-toolkit test fixture\n'
+      exit 0
+    fi
+    ;;
+  global)
+    printf 'global %s %s\n' "${2:-}" "${3:-}" >> "$log_file"
+    exit 0
+    ;;
+  reshim)
+    printf 'reshim %s\n' "${2:-all}" >> "$log_file"
+    exit 0
+    ;;
+esac
+
+printf 'unexpected asdf invocation: %s\n' "$*" >&2
+exit 1
+EOF
+chmod 755 "${bin_dir}/asdf"
+
+(
+  cd "$workspace"
+  PATH="${bin_dir}:/usr/bin:/bin" \
+  ASDF_DATA_DIR="$asdf_data_dir" \
+  FAKE_ASDF_LOG="$asdf_log" \
+  FAKE_CLI_LOG="$cli_log" \
+  GITHUB_PATH="$github_path_file" \
+  GITHUB_WORKSPACE="$workspace" \
+  CONFLUENCE_ACTION_PATH="${repo_root}/confluence" \
+  CONFLUENCE_INPUT_FOLDER='docs' \
+  CONFLUENCE_INPUT_DRY_RUN='true' \
+  CONFLUENCE_REPO_TOOLKIT_VERSION='latest' \
+  bash "${repo_root}/confluence/run.sh" >"$stdout_file" 2>"$stderr_file"
+)
+
+if ! grep -Fxq 'install 0.14.0' "$asdf_log"; then
+  echo 'expected repo-toolkit latest to resolve to the highest concrete version before install'
+  exit 1
+fi
+
+if ! grep -Fxq -- '--folder docs --dry-run' "$cli_log"; then
+  echo 'expected repo-toolkit-confluence to receive the resolved dry-run arguments'
+  exit 1
+fi
+
+if ! grep -Fq '🚀 repo-toolkit-confluence --folder docs --dry-run' "$stdout_file"; then
+  echo 'expected run.sh to execute the resolved repo-toolkit-confluence binary'
+  exit 1
+fi
+
+if grep -Fq 'Downloading repo-toolkit test fixture' "$stdout_file"; then
+  echo 'expected installer stdout to stay out of the resolved binary command substitution'
+  exit 1
+fi
+
+printf 'confluence shell tests passed\n'


### PR DESCRIPTION
## Summary
- resolve `CONFLUENCE_REPO_TOOLKIT_VERSION=latest` to the highest available concrete version before install
- keep confluence bootstrap logging on stderr so command substitution stays clean
- add a shell test that exercises the confluence bootstrap flow end to end
- include the new confluence shell test in the `test:shell` npm script

## Details
### Confluence bootstrap
`confluence/run.sh` now resolves `latest` by querying available `repo-toolkit` versions from asdf, selecting the highest semver-like release, and installing that concrete version. The script also routes installer/bootstrap output to stderr more consistently and preserves the resolved version for shim/global setup.

### Test coverage
A new `tests/test-confluence.sh` script simulates an asdf environment and verifies that:
- `latest` resolves to the highest available version
- `repo-toolkit-confluence` receives the expected arguments
- the resolved binary is executed successfully
- installer stdout does not leak into the command substitution used by the bootstrap flow

`package.json` updates the shell test suite so the new confluence test runs with the existing shell checks.

## Validation
- added targeted shell coverage for the confluence bootstrap path
- ensured the shell test entrypoint includes the new confluence test