### PR TITLE
Fix repo-toolkit version resolution in confluence script

### DIFF
--- a/confluence/run.sh
+++ b/confluence/run.sh
@@ -66,7 +66,7 @@ resolve_repo_toolkit_version() {
   fi
 
   local resolved_version
-  resolved_version="$(asdf list all repo-toolkit 2>/dev/null | grep -E '^[[:space:]]*[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?[[:space:]]*$' | tr -d '[:space:]' | sort -V | tail -n1 || true)"
+  resolved_version="$(asdf list all repo-toolkit 2>/dev/null | grep -E '^[[:space:]]*[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?[[:space:]]*$' | sort -V | tail -n1 | tr -d '[:space:]' || true)"
   if [[ -z "$resolved_version" ]]; then
     echo >&2 "⚠️  Unable to resolve the latest repo-toolkit version from asdf"
     return 1


### PR DESCRIPTION
## Summary

This change fixes the `confluence/run.sh` version resolution logic for `repo-toolkit`.

## What changed

- Adjusted the `asdf list all repo-toolkit` pipeline so version sorting happens before whitespace trimming.
- This preserves valid version strings for `sort -V` and still returns a clean version value afterward.

## Impact

- Improves reliability when resolving the latest available `repo-toolkit` version.
- Avoids incorrect ordering caused by stripping whitespace too early in the pipeline.

## Files changed

- `confluence/run.sh`