### PR TITLE
Fix confluence binary resolution with asdf

### DIFF
--- a/confluence/run.sh
+++ b/confluence/run.sh
@@ -96,6 +96,7 @@ install_repo_toolkit_via_asdf() {
   local toolkit_version="${CONFLUENCE_REPO_TOOLKIT_VERSION:-latest}"
   local install_version="$toolkit_version"
   local toolkit_plugin_url="${CONFLUENCE_REPO_TOOLKIT_PLUGIN_URL:-https://github.com/egose/repo-toolkit.git}"
+  CONFLUENCE_RESOLVED_BIN=""
 
   # Add plugin if not already present
   if ! asdf plugin list 2>/dev/null | grep -q "^repo-toolkit$"; then
@@ -115,9 +116,10 @@ install_repo_toolkit_via_asdf() {
   fi
 
   local actual_version="$install_version"
+  local direct_bin="${ASDF_DATA_DIR:-$HOME/.asdf}/installs/repo-toolkit/${actual_version}/bin/repo-toolkit-confluence"
   if [[ -n "$actual_version" && "$actual_version" != "latest" ]]; then
-    # Ensure shim resolves without .tool-versions in consumer repo
-    asdf global repo-toolkit "$actual_version" >&2 || true
+    # Best effort: asdf >=0.16 uses `set`, older versions used `global`.
+    asdf set -u repo-toolkit "$actual_version" >&2 || true
   fi
 
   local shims_dir="${ASDF_DATA_DIR:-$HOME/.asdf}/shims"
@@ -125,21 +127,16 @@ install_repo_toolkit_via_asdf() {
   export PATH="$shims_dir:$PATH"
   asdf reshim repo-toolkit >&2 || asdf reshim >&2 || true
 
-  # Prefer shim, but also try direct install path (bypasses .tool-versions requirement)
-  if command -v repo-toolkit-confluence >/dev/null 2>&1; then
+  # Prefer shim when it is actually runnable for the current workspace.
+  if asdf which repo-toolkit-confluence >/dev/null 2>&1 && command -v repo-toolkit-confluence >/dev/null 2>&1; then
     echo >&2 "✅ repo-toolkit ${actual_version:-$toolkit_version} installed via asdf"
     return 0
   fi
   if [[ -n "$actual_version" ]]; then
-    local direct_bin="${ASDF_DATA_DIR:-$HOME/.asdf}/installs/repo-toolkit/${actual_version}/bin/repo-toolkit-confluence"
     if [[ -x "$direct_bin" ]]; then
       echo >&2 "✅ repo-toolkit ${actual_version} installed via asdf (direct bin)"
-      # symlink into shims dir for PATH lookup
-      ln -sf "$direct_bin" "$shims_dir/repo-toolkit-confluence" 2>/dev/null || true
-      export PATH="$shims_dir:$PATH"
-      if command -v repo-toolkit-confluence >/dev/null 2>&1; then
-        return 0
-      fi
+      CONFLUENCE_RESOLVED_BIN="$direct_bin"
+      return 0
     fi
   fi
 
@@ -180,6 +177,10 @@ resolve_binary() {
 
   # 5. asdf repo-toolkit fallback (persistent, preferred over npx)
   if install_repo_toolkit_via_asdf; then
+    if [[ -n "${CONFLUENCE_RESOLVED_BIN:-}" && -x "${CONFLUENCE_RESOLVED_BIN}" ]]; then
+      echo "${CONFLUENCE_RESOLVED_BIN}"
+      return 0
+    fi
     if command -v repo-toolkit-confluence >/dev/null 2>&1; then
       echo "repo-toolkit-confluence"
       return 0

--- a/tests/test-confluence.sh
+++ b/tests/test-confluence.sh
@@ -83,9 +83,22 @@ CLI
     printf 'global %s %s\n' "${2:-}" "${3:-}" >> "$log_file"
     exit 0
     ;;
+  set)
+    printf 'set %s %s %s\n' "${2:-}" "${3:-}" "${4:-}" >> "$log_file"
+    exit 0
+    ;;
   reshim)
     printf 'reshim %s\n' "${2:-all}" >> "$log_file"
     exit 0
+    ;;
+  which)
+    if [[ "${2:-}" == "repo-toolkit-confluence" ]]; then
+      if [[ -x "${asdf_data_dir}/installs/repo-toolkit/0.14.0/bin/repo-toolkit-confluence" ]]; then
+        printf '%s\n' "${asdf_data_dir}/installs/repo-toolkit/0.14.0/bin/repo-toolkit-confluence"
+        exit 0
+      fi
+      exit 1
+    fi
     ;;
 esac
 
@@ -119,8 +132,8 @@ if ! grep -Fxq -- '--folder docs --dry-run' "$cli_log"; then
   exit 1
 fi
 
-if ! grep -Fq '🚀 repo-toolkit-confluence --folder docs --dry-run' "$stdout_file"; then
-  echo 'expected run.sh to execute the resolved repo-toolkit-confluence binary'
+if ! grep -Fq ' --folder docs --dry-run' "$stdout_file"; then
+  echo 'expected run.sh to execute the resolved repo-toolkit-confluence command with dry-run arguments'
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Update the confluence launcher to resolve repo-toolkit through asdf more reliably, including newer `asdf set` behavior and a direct installed binary fallback when the shim is not runnable in the current workspace.

## Changes

- Initialize and use a resolved binary path when asdf can provide a direct executable.
- Switch from `asdf global` to a best-effort `asdf set -u` for newer asdf versions.
- Check `asdf which` before trusting the shimmed `repo-toolkit-confluence` command.
- Fall back to the direct install binary path when available.
- Expand the shell test harness to cover `asdf set` and `asdf which` behavior.
- Relax the stdout assertion so the test verifies the executed dry-run arguments rather than the exact command prefix.

## Testing

- Updated `tests/test-confluence.sh` to simulate the new asdf command flow and validate the resolved execution path.