### PR TITLE
Add compose-sandbox action and tests

### DIFF
--- a/.github/workflows/test-compose-sandbox.yml
+++ b/.github/workflows/test-compose-sandbox.yml
@@ -1,0 +1,211 @@
+name: Test action compose-sandbox
+
+on:
+  pull_request:
+    paths:
+    - .github/workflows/test-compose-sandbox.yml
+    - compose-sandbox/**
+    - tests/fixtures/compose-sandbox/**
+    - tests/test-compose-sandbox.sh
+  push:
+    branches:
+    - main
+    paths:
+    - .github/workflows/test-compose-sandbox.yml
+    - compose-sandbox/**
+    - tests/fixtures/compose-sandbox/**
+    - tests/test-compose-sandbox.sh
+  workflow_dispatch:
+
+jobs:
+  compose-sandbox-success:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      with:
+        node-version: '26'
+
+    - name: Enable Corepack
+      run: corepack enable
+
+    - name: Install action repository dependencies
+      run: pnpm install --frozen-lockfile
+
+    - name: Verify Docker Compose v2
+      run: docker compose version
+
+    - name: Run compose sandbox (success)
+      id: sandbox
+      uses: ./compose-sandbox
+      with:
+        config: success.mjs
+        cwd: tests/fixtures/compose-sandbox
+        repo-toolkit-version: 0.17.0
+        artifact-name: compose-sandbox-success-logs
+        artifact-policy: always
+
+    - name: Assert success outputs
+      shell: bash
+      env:
+        OUTCOME: ${{ steps.sandbox.outputs.outcome }}
+        FAILED_PHASE: ${{ steps.sandbox.outputs.failed-phase }}
+        EVIDENCE_DIR: ${{ steps.sandbox.outputs.evidence-directory }}
+        MANIFEST: ${{ steps.sandbox.outputs.result-manifest }}
+        ARTIFACT: ${{ steps.sandbox.outputs.artifact-name }}
+      run: |
+        set -euo pipefail
+        echo "outcome=$OUTCOME"
+        echo "failed-phase=$FAILED_PHASE"
+        echo "evidence=$EVIDENCE_DIR"
+        echo "manifest=$MANIFEST"
+        echo "artifact=$ARTIFACT"
+        [[ "$OUTCOME" == "success" ]] || { echo "expected outcome success, got $OUTCOME" >&2; exit 1; }
+        [[ -z "$FAILED_PHASE" ]] || { echo "expected empty failed-phase on success" >&2; exit 1; }
+        [[ -n "$EVIDENCE_DIR" ]] || { echo "evidence-directory empty" >&2; exit 1; }
+        [[ -n "$MANIFEST" ]] || { echo "result-manifest empty" >&2; exit 1; }
+        [[ -f "$MANIFEST" ]] || { echo "manifest not found at $MANIFEST" >&2; exit 1; }
+        # Validate JSON without evaluating
+        python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$MANIFEST"
+        grep -q '"outcome": "success"' "$MANIFEST"
+        [[ "$ARTIFACT" == "compose-sandbox-success-logs" ]] || { echo "artifact name mismatch $ARTIFACT" >&2; exit 1; }
+        [[ -f "$EVIDENCE_DIR/ps.json" ]] || { echo "ps.json missing" >&2; exit 1; }
+        [[ -f "$EVIDENCE_DIR/logs.txt" ]] || { echo "logs.txt missing" >&2; exit 1; }
+        echo "success assertions passed"
+
+    - name: Verify no leaked containers/networks/volumes
+      if: always()
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "Checking for leaked cs-test-success resources"
+        leaked_containers="$(docker ps -a --filter "label=com.docker.compose.project=cs-test-success" --format '{{.ID}}' 2>/dev/null || true)"
+        if [[ -n "$leaked_containers" ]]; then
+          echo "leaked containers: $leaked_containers" >&2
+          docker ps -a --filter "label=com.docker.compose.project=cs-test-success" || true
+          exit 1
+        fi
+        leaked_networks="$(docker network ls --filter "label=com.docker.compose.project=cs-test-success" --format '{{.ID}}' 2>/dev/null || true)"
+        if [[ -n "$leaked_networks" ]]; then
+          echo "leaked networks: $leaked_networks" >&2
+          docker network ls --filter "label=com.docker.compose.project=cs-test-success" || true
+          exit 1
+        fi
+        # Volumes are pruned via compose down --volumes; check by label
+        leaked_volumes="$(docker volume ls --filter "label=com.docker.compose.project=cs-test-success" --format '{{.Name}}' 2>/dev/null || true)"
+        if [[ -n "$leaked_volumes" ]]; then
+          echo "leaked volumes: $leaked_volumes" >&2
+          docker volume ls --filter "label=com.docker.compose.project=cs-test-success" || true
+          exit 1
+        fi
+        echo "no leaked resources"
+
+  compose-sandbox-failure:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      with:
+        node-version: '26'
+
+    - name: Enable Corepack
+      run: corepack enable
+
+    - name: Install action repository dependencies
+      run: pnpm install --frozen-lockfile
+
+    - name: Verify Docker Compose v2
+      run: docker compose version
+
+    - name: Run compose sandbox (expected failure)
+      id: sandbox
+      continue-on-error: true
+      uses: ./compose-sandbox
+      with:
+        config: failure.mjs
+        cwd: tests/fixtures/compose-sandbox
+        repo-toolkit-version: 0.17.0
+        artifact-name: compose-sandbox-failure-logs
+        artifact-policy: failure
+
+    - name: Assert failure outputs and artifact
+      shell: bash
+      env:
+        OUTCOME: ${{ steps.sandbox.outputs.outcome }}
+        FAILED_PHASE: ${{ steps.sandbox.outputs.failed-phase }}
+        EVIDENCE_DIR: ${{ steps.sandbox.outputs.evidence-directory }}
+        MANIFEST: ${{ steps.sandbox.outputs.result-manifest }}
+        ARTIFACT: ${{ steps.sandbox.outputs.artifact-name }}
+        SANDBOX_OUTCOME: ${{ steps.sandbox.outcome }}
+      run: |
+        set -euo pipefail
+        echo "sandbox step outcome=$SANDBOX_OUTCOME"
+        echo "outcome=$OUTCOME"
+        echo "failed-phase=$FAILED_PHASE"
+        echo "evidence=$EVIDENCE_DIR"
+        echo "manifest=$MANIFEST"
+        echo "artifact=$ARTIFACT"
+        [[ "$SANDBOX_OUTCOME" == "failure" ]] || { echo "expected sandbox step failure, got $SANDBOX_OUTCOME" >&2; exit 1; }
+        [[ "$OUTCOME" == "failure" ]] || { echo "expected outcome failure, got $OUTCOME" >&2; exit 1; }
+        [[ -n "$FAILED_PHASE" ]] || { echo "failed-phase should be non-empty on failure" >&2; exit 1; }
+        [[ "$FAILED_PHASE" == "test" ]] || { echo "expected failed-phase test, got $FAILED_PHASE" >&2; exit 1; }
+        [[ -n "$EVIDENCE_DIR" ]] || { echo "evidence-directory empty" >&2; exit 1; }
+        [[ -n "$MANIFEST" ]] || { echo "result-manifest empty" >&2; exit 1; }
+        [[ -f "$MANIFEST" ]] || { echo "manifest not found" >&2; exit 1; }
+        python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$MANIFEST"
+        grep -q '"outcome": "failure"' "$MANIFEST"
+        [[ "$ARTIFACT" == "compose-sandbox-failure-logs" ]] || { echo "artifact mismatch $ARTIFACT" >&2; exit 1; }
+        [[ -f "$EVIDENCE_DIR/ps.json" ]] || { echo "ps.json missing" >&2; exit 1; }
+        echo "failure assertions passed"
+
+    - name: Verify failure artifact was uploaded
+      shell: bash
+      env:
+        ARTIFACT: ${{ steps.sandbox.outputs.artifact-name }}
+      run: |
+        set -euo pipefail
+        if [[ -z "$ARTIFACT" ]]; then
+          echo "artifact-name output empty on failure – upload should have been requested" >&2
+          exit 1
+        fi
+        echo "artifact $ARTIFACT was requested (upload-artifact step runs with always() when artifact-name set)"
+
+    - name: Verify no leaked containers/networks/volumes
+      if: always()
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "Checking for leaked cs-test-failure resources"
+        leaked_containers="$(docker ps -a --filter "label=com.docker.compose.project=cs-test-failure" --format '{{.ID}}' 2>/dev/null || true)"
+        if [[ -n "$leaked_containers" ]]; then
+          echo "leaked containers: $leaked_containers" >&2
+          docker ps -a --filter "label=com.docker.compose.project=cs-test-failure" || true
+          exit 1
+        fi
+        leaked_networks="$(docker network ls --filter "label=com.docker.compose.project=cs-test-failure" --format '{{.ID}}' 2>/dev/null || true)"
+        if [[ -n "$leaked_networks" ]]; then
+          echo "leaked networks: $leaked_networks" >&2
+          docker network ls --filter "label=com.docker.compose.project=cs-test-failure" || true
+          exit 1
+        fi
+        leaked_volumes="$(docker volume ls --filter "label=com.docker.compose.project=cs-test-failure" --format '{{.Name}}' 2>/dev/null || true)"
+        if [[ -n "$leaked_volumes" ]]; then
+          echo "leaked volumes: $leaked_volumes" >&2
+          docker volume ls --filter "label=com.docker.compose.project=cs-test-failure" || true
+          exit 1
+        fi
+        echo "no leaked resources"
+
+    - name: Enforce sandbox failure was preserved
+      if: always()
+      shell: bash
+      env:
+        SANDBOX_OUTCOME: ${{ steps.sandbox.outcome }}
+      run: |
+        if [[ "$SANDBOX_OUTCOME" != "failure" ]]; then
+          echo "sandbox should have failed but outcome is $SANDBOX_OUTCOME" >&2
+          exit 1
+        fi
+        echo "failure preserved"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This repository contains several reusable composite GitHub Actions.
 | --- | --- |
 | [`asdf-install`](./asdf-install/README.md) | Installs the `asdf` CLI and adds it to `PATH`. |
 | [`asdf-tools`](./asdf-tools/README.md) | Installs `asdf` and tool versions from `.tool-versions`. |
+| [`compose-sandbox`](./compose-sandbox/README.md) | Runs a repository-defined Docker Compose sandbox through the repo-toolkit lifecycle engine. |
 | [`confluence`](./confluence/README.md) | Syncs a folder of markdown docs to Confluence pages and attachments. |
 | [`docker-build-push`](./docker-build-push/README.md) | Builds and pushes a Docker image, with optional Trivy scanning. |
 | [`npm-packages`](./npm-packages/README.md) | Runs `npm install` across one or more package directories. |

--- a/compose-sandbox/README.md
+++ b/compose-sandbox/README.md
@@ -1,0 +1,187 @@
+# Run Docker Compose Sandbox
+
+Runs a repository-defined Docker Compose test sandbox through the deterministic lifecycle engine [`@repo-toolkit/compose-sandbox`](https://github.com/egose/repo-toolkit/tree/main/packages/compose-sandbox) (`repo-toolkit-compose-sandbox`). The action is a thin composite wrapper: it resolves the pinned toolkit CLI, invokes the engine with a validated config file, writes a redacted GitHub summary from the engine result manifest, and optionally uploads the engine evidence directory.
+
+## Responsibilities
+
+| Layer | Owns | Does not own |
+| --- | --- | --- |
+| **Action** (`egose/actions/compose-sandbox`) | Input validation, pinned CLI resolution via explicit override → workspace `node_modules/.bin` → `PATH` → exact-version `asdf` install, array-based invocation without shell evaluation, `always()` summary/artifact steps, stable outputs from the engine manifest, redacted logging | Compose startup, readiness polling, test execution, log collection, cleanup |
+| **Engine** (`@repo-toolkit/compose-sandbox`) | `validate → prepare → start → wait → test → collect evidence → clean up`, structured `docker compose` arrays, TCP/HTTP/service probes, bounded evidence (`ps.json`, `logs.txt`, `result.json`), signal/timeout/cleanup guarantees | Checkout, package installation, GitHub artifact upload, step summaries |
+| **Consumer** (calling repository) | `actions/checkout`, installing project dependencies (`pnpm`/`npm`/`yarn`/`Bats`/`Playwright`/clients), providing a valid toolkit config file, providing a runner with Docker Compose v2 | Action-internal binary resolution, engine lifecycle implementation |
+
+Check responsibilities before filing issues: service definitions, probes, and test commands belong in the toolkit config file, not as action inputs.
+
+## Prerequisites
+
+The caller must provide before invoking the action:
+
+1. **Checkout** – `actions/checkout` (or equivalent) so `cwd` and `config` exist.
+2. **Project dependencies** – install whatever the sandbox test needs (e.g. `pnpm install --frozen-lockfile`, `npm ci`, Playwright browsers, Bats, `mongosh`, `psql` client). The action never installs consumer toolchains.
+3. **Valid toolkit config** – a JSON, `.mjs`, or `.cjs` file loadable by `@repo-toolkit/publish-package` `loadConfigFile` (see engine [README](https://github.com/egose/repo-toolkit/tree/main/packages/compose-sandbox) and `website/docs/packages/compose-sandbox.md`).
+4. **Docker Compose v2** – runner must have `docker compose` (not legacy `docker-compose`). Engine preflights `docker compose version`.
+
+`--help` and `--dry-run` require neither Docker nor network access.
+
+## Usage
+
+All examples pin both the action and the toolkit to immutable refs. Replace `<commit-sha>` with the exact commit SHA from the release you intend to run (check the release notes for the tested `repo-toolkit-version`, current default `0.17.0`).
+
+### Minimal
+
+```yaml
+jobs:
+  sandbox:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with: { node-version: '26' }
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run integration sandbox
+        id: sandbox
+        uses: egose/actions/compose-sandbox@<commit-sha>
+        with:
+          config: sandbox/ci-sandbox.mjs
+          artifact-name: compose-logs-${{ matrix.attempt }}
+```
+
+### Database-shaped (mixed TCP/HTTP/one-shot + Bats)
+
+Mirrors the `_database-tools` integration sandbox: two Compose files, environment file, bind-mount preparation, TCP + HTTP + `service-completed` probes, Bats test command, volume/orphan cleanup, and per-matrix artifact names.
+
+Toolkit config `sandbox/database-sandbox.mjs`:
+
+```js
+export default {
+  cwd: '.',
+  compose: {
+    files: ['sandbox/docker-compose.yml', 'sandbox/docker-compose.ci.yml'],
+    envFile: 'sandbox/.env.dev',
+    projectName: 'db-it',
+  },
+  prepare: {
+    directories: ['sandbox/data/pg', 'sandbox/data/mongo', 'sandbox/data/minio'],
+    copies: [{ from: 'sandbox/assets', to: 'sandbox/work/assets' }],
+  },
+  readiness: [
+    { type: 'tcp', host: '127.0.0.1', port: 5432 },
+    { type: 'tcp', host: '127.0.0.1', port: 27017 },
+    { type: 'http', url: 'http://127.0.0.1:9000/minio/health/live' },
+    { type: 'service-completed', service: 'minio-init' },
+  ],
+  test: { executable: 'pnpm', args: ['exec', 'bats', 'tests/integration'] },
+  evidence: { directory: '.ci-logs', capture: 'onFailure' },
+  cleanup: { volumes: true, removeOrphans: true, paths: ['sandbox/data/pg', 'sandbox/data/mongo'] },
+};
+```
+
+Workflow:
+
+```yaml
+- name: Run database sandbox
+  id: db-sandbox
+  uses: egose/actions/compose-sandbox@<commit-sha>
+  with:
+    config: sandbox/database-sandbox.mjs
+    cwd: ${{ github.workspace }}
+    repo-toolkit-version: 0.17.0
+    artifact-name: integration-service-logs-${{ matrix.startup-attempt }}
+    artifact-policy: failure
+```
+
+### Template-shaped (three HTTP endpoints + Playwright)
+
+Mirrors the `_vite-fastapi-postgres-template` Playwright sandbox: single Compose file, three HTTP probes, Playwright test command, always-capture evidence for post-run debugging.
+
+Toolkit config `sandbox/app-sandbox.mjs`:
+
+```js
+export default {
+  cwd: '.',
+  compose: { files: ['sandbox/docker-compose.yml'], projectName: 'vfpt' },
+  readiness: [
+    { type: 'http', url: 'http://127.0.0.1:8000/api/v1/info' },
+    { type: 'http', url: 'http://127.0.0.1:3000/health' },
+    { type: 'http', url: 'http://127.0.0.1:8080/auth/health' },
+  ],
+  test: { executable: 'pnpm', args: ['playwright', 'test'] },
+  evidence: { directory: '.ci-logs', capture: 'always' },
+  cleanup: { volumes: true, removeOrphans: true },
+};
+```
+
+Workflow:
+
+```yaml
+- name: Run app sandbox
+  id: app-sandbox
+  uses: egose/actions/compose-sandbox@<commit-sha>
+  with:
+    config: sandbox/app-sandbox.mjs
+    artifact-name: playwright-logs
+    artifact-policy: always
+```
+
+> The examples above illustrate the intended contract. They do not claim that `_database-tools` or `_vite-fastapi-postgres-template` have been migrated; repository migrations are tracked separately and retain their existing `actions/checkout`, setup, matrix, and permission policies.
+
+## Inputs
+
+| Name | Required | Default | Description |
+| --- | --- | --- | --- |
+| `config` | Yes | — | Path to the toolkit config file (JSON, `.mjs`, or `.cjs`). Resolved relative to `cwd`. |
+| `cwd` | No | `${{ github.workspace }}` | Working directory the engine resolves relative paths against. Must be inside the workspace when provided. |
+| `compose-sandbox-bin` | No | `` | Explicit path to the `repo-toolkit-compose-sandbox` executable. When set, bypasses workspace/`PATH`/`asdf` resolution. Useful for local development and fixture tests. |
+| `repo-toolkit-version` | No | `0.17.0` | Exact `repo-toolkit` version to install via `asdf` when the binary is not found. Must be an exact semver; `latest` is rejected. Pinned to the version tested with this action release. |
+| `repo-toolkit-plugin-url` | No | `https://github.com/egose/repo-toolkit.git` | Git URL for the `repo-toolkit` `asdf` plugin. |
+| `artifact-name` | No | `compose-sandbox-logs` | Name of the GitHub artifact uploaded from the evidence directory. Ignored when `artifact-policy` is `never` or when no evidence is produced. |
+| `artifact-policy` | No | `failure` | When to upload evidence. One of `failure` (only on sandbox failure), `always`, or `never`. |
+| `artifact-retention-days` | No | `` | Retention days for the uploaded artifact. Empty uses the repository default. Must be a positive integer when set. |
+
+No input accepts a multiline shell command. Test and readiness commands belong in the structured toolkit config (`test.executable` + `args` arrays).
+
+### Pinned toolkit version
+
+`repo-toolkit-version` defaults to the exact version tested with this action release (`0.17.0`), not `latest`. Every network installation path validates that the requested version is an exact semver and installs that version only. Third-party GitHub Actions used by the action itself are pinned to full commit SHAs. Consumers should keep `uses: egose/actions/compose-sandbox@<sha>` pinned to a commit SHA as well.
+
+## Outputs
+
+| Name | Description |
+| --- | --- |
+| `outcome` | Lifecycle outcome from the engine manifest: `success` or `failure`. |
+| `failed-phase` | Phase that failed when `outcome` is `failure` (`validate`, `prepare`, `preflight`, `start`, `readiness`, `test`, `evidence`, or `cleanup`). Empty on success. |
+| `evidence-directory` | Path to the evidence directory (`ps.json`, `logs.txt`, `result.json`), resolved relative to `cwd`. Empty when no evidence was produced. |
+| `result-manifest` | Path to `result.json` inside the evidence directory. Machine-readable manifest containing `phase`, `outcome`, `timings`, `evidenceFiles`, and sanitized `errors`. |
+| `artifact-name` | Name of the uploaded artifact when an upload was performed, otherwise empty. |
+
+Outputs and the GitHub step summary are sourced from the validated engine `result.json` manifest, never by parsing human log text. Manifest values are validated without `eval`/`source`; malformed manifests fail the action without exposing secrets. `test.env` and probe `env` values are never written to logs, summaries, or outputs.
+
+## Artifact and summary behavior
+
+- **Engine invocation** runs in its own composite step.
+- **Summary** (`GITHUB_STEP_SUMMARY`) and **artifact upload** each run in separate steps under `if: always()` so they execute even when the engine fails. Engine failure remains the action outcome; artifact upload failures are surfaced without turning a failed sandbox into success.
+- Default `artifact-policy: failure` uploads only after failure. `always` uploads on success and failure; `never` disables upload.
+- The action uploads only the bounded engine evidence directory, never unbounded raw Compose logs.
+
+## Security
+
+- Every caller-controlled value is passed to `run.sh` through environment variables (`COMPOSE_SANDBOX_INPUT_*` + `COMPOSE_SANDBOX_ACTION_PATH`). No input is interpolated into shell source or evaluated via `bash -c`/`eval`.
+- CLI invocation uses Bash arrays for executable + arguments; whitespace or metacharacters in `config`/`cwd` are passed as single literal arguments.
+- Environment values, config contents, and probe secrets are never echoed to logs or summaries; result manifest errors are sanitized and ANSI-stripped.
+- No `latest` or unpinned `npx` downloads. Network installs use the exact `repo-toolkit-version`.
+
+## Migrating consumers
+
+Consumers keep their existing `actions/checkout`, `actions/setup-node`, `pnpm`/`npm`/`yarn` installs, matrix definitions, and permissions. To adopt this action:
+
+1. Install Docker Compose v2 on the runner (GitHub-hosted `ubuntu-24.04` already has it).
+2. Move repository-specific readiness and test behavior into a toolkit config file (`test.executable`/`args` arrays, `readiness` probes).
+3. Replace `make DAEMON=true up` / `make logs` / `make down` or raw `docker-compose` blocks with a single `uses: egose/actions/compose-sandbox@<sha>` step per the examples above.
+
+See the engine package docs for full configuration reference:
+
+- [`@repo-toolkit/compose-sandbox` README](https://github.com/egose/repo-toolkit/tree/main/packages/compose-sandbox)
+- [`website/docs/packages/compose-sandbox.md`](https://github.com/egose/repo-toolkit/blob/main/website/docs/packages/compose-sandbox.md)

--- a/compose-sandbox/action.yml
+++ b/compose-sandbox/action.yml
@@ -1,0 +1,87 @@
+name: Run Docker Compose Sandbox
+description: Run a repository-defined Docker Compose sandbox through the repo-toolkit compose-sandbox lifecycle engine
+inputs:
+  config:
+    description: Path to the compose-sandbox config file (JSON, .mjs, or .cjs) relative to cwd
+    required: true
+  cwd:
+    description: Working directory the engine resolves config and relative paths against
+    required: false
+    default: ${{ github.workspace }}
+  compose-sandbox-bin:
+    description: Path to the repo-toolkit-compose-sandbox binary. Leave empty to auto-resolve from workspace node_modules/.bin, PATH, or asdf.
+    required: false
+    default: ''
+  repo-toolkit-version:
+    description: Exact repo-toolkit version to install via asdf when the binary is not found. Must be an exact semver (e.g. 0.17.0), not latest.
+    required: false
+    default: 0.17.0
+  repo-toolkit-plugin-url:
+    description: Git URL for the repo-toolkit asdf plugin
+    required: false
+    default: https://github.com/egose/repo-toolkit.git
+  artifact-name:
+    description: Name for the uploaded evidence artifact
+    required: false
+    default: compose-sandbox-logs
+  artifact-policy:
+    description: When to upload the evidence artifact. One of failure, always, never. Default failure uploads only when the sandbox fails.
+    required: false
+    default: failure
+  artifact-retention-days:
+    description: Retention days for the uploaded artifact. Leave empty for the repository default.
+    required: false
+    default: ''
+outputs:
+  outcome:
+    description: Lifecycle outcome from the engine result manifest (success or failure)
+    value: ${{ steps.sandbox.outputs.outcome }}
+  failed-phase:
+    description: Phase that failed when outcome is failure (validate, prepare, preflight, start, readiness, test, evidence, or cleanup)
+    value: ${{ steps.sandbox.outputs.failed-phase }}
+  evidence-directory:
+    description: Absolute or cwd-relative path to the engine evidence directory containing ps.json, logs.txt, and result.json
+    value: ${{ steps.sandbox.outputs.evidence-directory }}
+  result-manifest:
+    description: Absolute or cwd-relative path to the engine result manifest (result.json) inside the evidence directory
+    value: ${{ steps.sandbox.outputs.result-manifest }}
+  artifact-name:
+    description: Name of the uploaded artifact when an upload was performed, otherwise empty
+    value: ${{ steps.sandbox.outputs.artifact-name }}
+runs:
+  using: composite
+  steps:
+  - id: sandbox
+    name: Run compose sandbox engine
+    shell: bash
+    env:
+      COMPOSE_SANDBOX_INPUT_CONFIG: ${{ inputs.config }}
+      COMPOSE_SANDBOX_INPUT_CWD: ${{ inputs.cwd }}
+      COMPOSE_SANDBOX_INPUT_BIN: ${{ inputs.compose-sandbox-bin }}
+      COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION: ${{ inputs.repo-toolkit-version }}
+      COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_PLUGIN_URL: ${{ inputs.repo-toolkit-plugin-url }}
+      COMPOSE_SANDBOX_INPUT_ARTIFACT_NAME: ${{ inputs.artifact-name }}
+      COMPOSE_SANDBOX_INPUT_ARTIFACT_POLICY: ${{ inputs.artifact-policy }}
+      COMPOSE_SANDBOX_INPUT_ARTIFACT_RETENTION_DAYS: ${{ inputs.artifact-retention-days }}
+      COMPOSE_SANDBOX_ACTION_PATH: ${{ github.action_path }}
+    run: bash "${{ github.action_path }}/run.sh"
+  - name: Write sandbox summary
+    if: always()
+    shell: bash
+    env:
+      COMPOSE_SANDBOX_ACTION_PATH: ${{ github.action_path }}
+      COMPOSE_SANDBOX_INPUT_ARTIFACT_NAME: ${{ inputs.artifact-name }}
+      COMPOSE_SANDBOX_INPUT_ARTIFACT_POLICY: ${{ inputs.artifact-policy }}
+      COMPOSE_SANDBOX_RESULT_MANIFEST: ${{ steps.sandbox.outputs.result-manifest }}
+      COMPOSE_SANDBOX_EVIDENCE_DIRECTORY: ${{ steps.sandbox.outputs.evidence-directory }}
+      COMPOSE_SANDBOX_OUTCOME: ${{ steps.sandbox.outputs.outcome }}
+      COMPOSE_SANDBOX_FAILED_PHASE: ${{ steps.sandbox.outputs.failed-phase }}
+    run: bash "${{ github.action_path }}/summarize.sh"
+  - name: Upload sandbox evidence
+    if: ${{ always() && steps.sandbox.outputs.artifact-name != '' && steps.sandbox.outputs.evidence-directory != '' }}
+    uses: actions/upload-artifact@65462800fd760344a2a7ede2ed4f50aede65e8c
+    with:
+      name: ${{ steps.sandbox.outputs.artifact-name }}
+      path: ${{ steps.sandbox.outputs.evidence-directory }}
+      retention-days: ${{ inputs.artifact-retention-days }}
+      if-no-files-found: warn

--- a/compose-sandbox/run.sh
+++ b/compose-sandbox/run.sh
@@ -1,0 +1,551 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ----------------------------------------------------------------------------
+# Run repo-toolkit-compose-sandbox lifecycle engine.
+# Inputs are sourced from COMPOSE_SANDBOX_INPUT_* env vars set by action.yml.
+# No caller-controlled string is evaluated as shell source; CLI is built
+# with Bash arrays. Version resolution is pinned to an exact semver.
+# ----------------------------------------------------------------------------
+
+COMPOSE_SANDBOX_RESOLVED_BIN=""
+
+validate_semver() {
+  local v="$1"
+  local label="$2"
+  if [[ -z "$v" ]]; then
+    echo "❌ $label must be an exact semver, got empty" >&2
+    return 1
+  fi
+  if [[ "$v" == "latest" ]]; then
+    echo "❌ $label must be an exact semver, got 'latest' (pinned version required)" >&2
+    return 1
+  fi
+  # semver: X.Y.Z with optional prerelease/build
+  if ! [[ "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+    echo "❌ $label must be an exact semver (e.g. 0.17.0), got: $v" >&2
+    return 1
+  fi
+  if [[ "$v" == *".."* || "$v" == *"//"* ]]; then
+    echo "❌ $label contains invalid sequence: $v" >&2
+    return 1
+  fi
+}
+
+validate_artifact_name() {
+  local name="$1"
+  if [[ -z "$name" ]]; then
+    echo "❌ artifact-name must be non-empty" >&2
+    return 1
+  fi
+  if [[ "$name" == *"/"* ]]; then
+    echo "❌ artifact-name must not contain path separators: $name" >&2
+    return 1
+  fi
+  if [[ "$name" == *"\\"* ]]; then
+    echo "❌ artifact-name must not contain path separators: $name" >&2
+    return 1
+  fi
+  # NUL check is unnecessary in Bash (env vars cannot contain NUL) and would
+  # incorrectly match every string because $'\0' expands to empty. Skip.
+  # GitHub artifact names: printable, no colon, no slash, limited length
+  if ! [[ "$name" =~ ^[A-Za-z0-9._-]+$ ]]; then
+    # Allow hyphens, dots, underscores between alphanum; reject spaces/slashes
+    # Example from spec: integration-service-logs-1 is valid. We keep strict
+    # so malicious names cannot escape.
+    echo "❌ artifact-name must match ^[A-Za-z0-9._-]+\\$ : $name" >&2
+    return 1
+  fi
+  if [[ ${#name} -gt 100 ]]; then
+    echo "❌ artifact-name must be <=100 chars" >&2
+    return 1
+  fi
+}
+
+validate_retention() {
+  local v="$1"
+  if [[ -z "$v" ]]; then
+    return 0
+  fi
+  if ! [[ "$v" =~ ^[0-9]+$ ]]; then
+    echo "❌ artifact-retention-days must be a positive integer, got: $v" >&2
+    return 1
+  fi
+  if [[ "$v" -lt 1 || "$v" -gt 90 ]]; then
+    echo "❌ artifact-retention-days must be 1-90, got: $v" >&2
+    return 1
+  fi
+}
+
+resolve_path() {
+  local base="$1"
+  local target="$2"
+  local label="$3"
+  # NUL cannot be represented in Bash strings; env vars never contain NUL.
+  # The toolkit validates path NULs separately.
+  local joined
+  if [[ "$target" == /* ]]; then
+    joined="$target"
+  else
+    joined="${base%/}/${target}"
+  fi
+  # Use realpath -m if available (does not require existence), else python3, else naive
+  local resolved=""
+  if command -v realpath >/dev/null 2>&1 && realpath -m / >/dev/null 2>&1; then
+    resolved="$(realpath -m "$joined" 2>/dev/null || echo "$joined")"
+  elif command -v python3 >/dev/null 2>&1; then
+    resolved="$(python3 -c 'import os,sys; print(os.path.normpath(os.path.join(sys.argv[1], sys.argv[2])) if not os.path.isabs(sys.argv[2]) else os.path.normpath(sys.argv[2]))' "$base" "$target" 2>/dev/null || echo "$joined")"
+  else
+    resolved="$joined"
+  fi
+  # Trim trailing slash except root
+  if [[ "$resolved" != "/" ]]; then
+    resolved="${resolved%/}"
+  fi
+  echo "$resolved"
+}
+
+ensure_asdf_available() {
+  if command -v asdf >/dev/null 2>&1; then
+    return 0
+  fi
+  # Try common asdf locations
+  if [[ -x "$HOME/.asdf/bin/asdf" ]]; then
+    export PATH="$HOME/.asdf/bin:$HOME/.asdf/shims:$PATH"
+    if command -v asdf >/dev/null 2>&1; then return 0; fi
+  fi
+  if [[ -x "/opt/asdf-vm/bin/asdf" ]]; then
+    export PATH="/opt/asdf-vm/bin:$PATH"
+    if command -v asdf >/dev/null 2>&1; then return 0; fi
+  fi
+  # Fall back to installing via asdf-install if available
+  local asdf_version="v0.15.0"
+  local install_sh="${COMPOSE_SANDBOX_ACTION_PATH:?}/../asdf-install/install.sh"
+  if [[ -f "$install_sh" ]]; then
+    echo >&2 "➡️ Installing asdf ${asdf_version} for repo-toolkit..."
+    ASDF_VERSION="${asdf_version}" bash "$install_sh" >&2 || return 1
+    export PATH="${RUNNER_TEMP:-/tmp}/asdf-bin:${ASDF_DATA_DIR:-$HOME/.asdf}/shims:$PATH"
+    if command -v asdf >/dev/null 2>&1; then return 0; fi
+  fi
+  echo >&2 "❌ asdf is unavailable and could not be installed"
+  return 1
+}
+
+install_repo_toolkit_via_asdf() {
+  if command -v repo-toolkit-compose-sandbox >/dev/null 2>&1; then
+    return 0
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    echo >&2 "⚠️ jq not found; cannot install repo-toolkit via asdf (requires jq)."
+    return 1
+  fi
+  if ! command -v node >/dev/null 2>&1; then
+    echo >&2 "⚠️ node not found; cannot install repo-toolkit via asdf."
+    return 1
+  fi
+  ensure_asdf_available || return 1
+
+  local toolkit_version="${COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION:-0.17.0}"
+  local toolkit_plugin_url="${COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_PLUGIN_URL:-https://github.com/egose/repo-toolkit.git}"
+  validate_semver "$toolkit_version" "repo-toolkit-version" || return 1
+  COMPOSE_SANDBOX_RESOLVED_BIN=""
+
+  if ! asdf plugin list 2>/dev/null | grep -q "^repo-toolkit$"; then
+    asdf plugin add repo-toolkit "$toolkit_plugin_url" >&2 || true
+  fi
+
+  echo >&2 "➡️ repo-toolkit-compose-sandbox not found; installing repo-toolkit ${toolkit_version} via asdf..."
+
+  if ! asdf install repo-toolkit "$toolkit_version" >&2; then
+    echo >&2 "⚠️ asdf repo-toolkit install failed for version ${toolkit_version}"
+    return 1
+  fi
+
+  local direct_bin="${ASDF_DATA_DIR:-$HOME/.asdf}/installs/repo-toolkit/${toolkit_version}/bin/repo-toolkit-compose-sandbox"
+  if [[ -n "$toolkit_version" ]]; then
+    asdf set -u repo-toolkit "$toolkit_version" >&2 || true
+  fi
+  local shims_dir="${ASDF_DATA_DIR:-$HOME/.asdf}/shims"
+  if [[ -n "${GITHUB_PATH:-}" ]]; then
+    echo "$shims_dir" >> "$GITHUB_PATH" 2>/dev/null || true
+  fi
+  export PATH="$shims_dir:$PATH"
+  asdf reshim repo-toolkit >&2 || asdf reshim >&2 || true
+
+  if asdf which repo-toolkit-compose-sandbox >/dev/null 2>&1 && command -v repo-toolkit-compose-sandbox >/dev/null 2>&1; then
+    echo >&2 "✅ repo-toolkit ${toolkit_version} installed via asdf"
+    return 0
+  fi
+  if [[ -x "$direct_bin" ]]; then
+    echo >&2 "✅ repo-toolkit ${toolkit_version} installed via asdf (direct bin)"
+    COMPOSE_SANDBOX_RESOLVED_BIN="$direct_bin"
+    return 0
+  fi
+  echo >&2 "⚠️ repo-toolkit-compose-sandbox still not found after asdf install"
+  return 1
+}
+
+resolve_binary() {
+  # 1. Explicit override
+  if [[ -n "${COMPOSE_SANDBOX_INPUT_BIN:-}" ]]; then
+    local bin_input="${COMPOSE_SANDBOX_INPUT_BIN}"
+    if [[ -x "$bin_input" ]]; then
+      echo "$bin_input"
+      return 0
+    fi
+    if command -v "$bin_input" >/dev/null 2>&1; then
+      # command -v resolves via PATH; still validate it is not empty
+      local resolved
+      resolved="$(command -v "$bin_input" 2>/dev/null || echo "$bin_input")"
+      echo "$resolved"
+      return 0
+    fi
+    echo >&2 "❌ compose-sandbox-bin override not found or not executable: $bin_input"
+    return 1
+  fi
+
+  # 2. Workspace node_modules/.bin
+  local ws_root="${GITHUB_WORKSPACE:-$(pwd)}"
+  local candidates=()
+  candidates+=("$ws_root/node_modules/.bin/repo-toolkit-compose-sandbox")
+  # Also try cwd-relative lookup (runner workspace may differ from cwd)
+  local cwd_hint="${COMPOSE_SANDBOX_INPUT_CWD:-$ws_root}"
+  if [[ "$cwd_hint" != "$ws_root" ]]; then
+    # Resolve cwd_hint to absolute for lookup; best effort without validation yet
+    local cwd_abs_hint
+    cwd_abs_hint="$(resolve_path "$ws_root" "$cwd_hint" "cwd" 2>/dev/null || echo "$cwd_hint")"
+    candidates+=("$cwd_abs_hint/node_modules/.bin/repo-toolkit-compose-sandbox")
+  fi
+  for cand in "${candidates[@]}"; do
+    if [[ -n "$cand" && -x "$cand" ]]; then
+      echo "$cand"
+      return 0
+    fi
+  done
+
+  # 3. ACTION_PATH node_modules/.bin
+  local action_bin="${COMPOSE_SANDBOX_ACTION_PATH:-}/node_modules/.bin/repo-toolkit-compose-sandbox"
+  if [[ -n "$action_bin" && -x "$action_bin" ]]; then
+    echo "$action_bin"
+    return 0
+  fi
+
+  # 4. PATH lookup (includes asdf shims)
+  if command -v repo-toolkit-compose-sandbox >/dev/null 2>&1; then
+    echo "repo-toolkit-compose-sandbox"
+    return 0
+  fi
+
+  # 5. asdf fallback with exact version
+  if install_repo_toolkit_via_asdf; then
+    if [[ -n "${COMPOSE_SANDBOX_RESOLVED_BIN:-}" && -x "${COMPOSE_SANDBOX_RESOLVED_BIN}" ]]; then
+      echo "${COMPOSE_SANDBOX_RESOLVED_BIN}"
+      return 0
+    fi
+    if command -v repo-toolkit-compose-sandbox >/dev/null 2>&1; then
+      echo "repo-toolkit-compose-sandbox"
+      return 0
+    fi
+  fi
+
+  echo >&2 "❌ repo-toolkit-compose-sandbox not found. Install it via pnpm add -D @repo-toolkit/compose-sandbox@${COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION:-0.17.0} or ensure asdf is available."
+  return 1
+}
+
+find_manifest() {
+  local cwd_abs="$1"
+  # Try known defaults first for speed
+  local candidates=(
+    "$cwd_abs/.compose-sandbox-logs/result.json"
+    "$cwd_abs/.ci-logs/result.json"
+  )
+  for c in "${candidates[@]}"; do
+    if [[ -f "$c" ]]; then
+      echo "$c"
+      return 0
+    fi
+  done
+  # Fallback: find any result.json within cwd (max depth 4)
+  local found=""
+  if command -v find >/dev/null 2>&1; then
+    found="$(find "$cwd_abs" -maxdepth 4 -type f -name "result.json" 2>/dev/null | head -n 1 || true)"
+    if [[ -n "$found" && -f "$found" ]]; then
+      echo "$found"
+      return 0
+    fi
+  fi
+  # Last resort: check evidence dir derived from config? skip
+  return 1
+}
+
+parse_manifest_field() {
+  local manifest="$1"
+  local field="$2"
+  # Use python3 for safe JSON parsing without eval
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$manifest" "$field" <<'PY' 2>/dev/null || echo ""
+import json, sys
+path = sys.argv[1]
+field = sys.argv[2]
+try:
+  with open(path, 'r', encoding='utf-8') as f:
+    data = json.load(f)
+  val = data.get(field, "")
+  if isinstance(val, str):
+    print(val)
+  elif val is None:
+    print("")
+  else:
+    # For phase/outcome etc, coerce to string but avoid dumping objects
+    if isinstance(val, (dict, list)):
+      print("")
+    else:
+      print(str(val))
+except Exception:
+  print("")
+PY
+  elif command -v jq >/dev/null 2>&1; then
+    jq -r --arg f "$field" '.[$f] // empty' "$manifest" 2>/dev/null | head -n 1 || echo ""
+  else
+    echo ""
+  fi
+}
+
+sanitize_for_output() {
+  # Strip ANSI, truncate, and ensure no newlines in single-line outputs
+  local v="$1"
+  # Remove ANSI sequences
+  if command -v sed >/dev/null 2>&1; then
+    v="$(printf '%s' "$v" | sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g' 2>/dev/null || printf '%s' "$v")"
+  fi
+  # Remove newlines and carriage returns for GITHUB_OUTPUT single line
+  v="${v//$'\n'/ }"
+  v="${v//$'\r'/ }"
+  # Truncate to 2000 chars
+  if [[ ${#v} -gt 2000 ]]; then
+    v="${v:0:2000}"
+  fi
+  # Also strip leading/trailing whitespace
+  v="$(printf '%s' "$v" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' 2>/dev/null || printf '%s' "$v")"
+  printf '%s' "$v"
+}
+
+main() {
+  local config_input="${COMPOSE_SANDBOX_INPUT_CONFIG:-}"
+  if [[ -z "$config_input" ]]; then
+    echo >&2 "❌ config input is required"
+    exit 1
+  fi
+  local policy="${COMPOSE_SANDBOX_INPUT_ARTIFACT_POLICY:-failure}"
+  case "$policy" in
+    failure|always|never) ;;
+    *)
+      echo >&2 "❌ artifact-policy must be one of failure, always, never; got: $policy"
+      exit 1
+      ;;
+  esac
+
+  local artifact_name_input="${COMPOSE_SANDBOX_INPUT_ARTIFACT_NAME:-compose-sandbox-logs}"
+  if [[ "$policy" != "never" && -n "$artifact_name_input" ]]; then
+    validate_artifact_name "$artifact_name_input" || exit 1
+  fi
+
+  local retention="${COMPOSE_SANDBOX_INPUT_ARTIFACT_RETENTION_DAYS:-}"
+  validate_retention "$retention" || exit 1
+
+  local version_input="${COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION:-0.17.0}"
+  validate_semver "$version_input" "repo-toolkit-version" || exit 1
+
+  local cwd_input="${COMPOSE_SANDBOX_INPUT_CWD:-${GITHUB_WORKSPACE:-$(pwd)}}"
+  if [[ -z "$cwd_input" ]]; then
+    cwd_input="$(pwd)"
+  fi
+  # Resolve cwd to absolute canonical path (requires existence)
+  local cwd_abs=""
+  if command -v realpath >/dev/null 2>&1 && realpath -m / >/dev/null 2>&1; then
+    cwd_abs="$(realpath -m "$cwd_input" 2>/dev/null || echo "$cwd_input")"
+  elif command -v python3 >/dev/null 2>&1; then
+    cwd_abs="$(python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' "$cwd_input" 2>/dev/null || echo "$cwd_input")"
+  else
+    cwd_abs="$cwd_input"
+  fi
+  # For existence check, use realpath without -m if possible, but allow -m result
+  # Ensure cwd exists and is directory
+  if [[ ! -d "$cwd_abs" ]]; then
+    # Try resolving relative to workspace if not absolute
+    if [[ "$cwd_abs" != /* && -n "${GITHUB_WORKSPACE:-}" ]]; then
+      local alt
+      alt="$(resolve_path "$GITHUB_WORKSPACE" "$cwd_input" "cwd" 2>/dev/null || echo "")"
+      if [[ -n "$alt" && -d "$alt" ]]; then
+        cwd_abs="$alt"
+      else
+        echo >&2 "❌ cwd does not exist or is not a directory: $cwd_abs"
+        exit 1
+      fi
+    else
+      echo >&2 "❌ cwd does not exist or is not a directory: $cwd_abs"
+      exit 1
+    fi
+  fi
+
+  local config_abs
+  config_abs="$(resolve_path "$cwd_abs" "$config_input" "config")" || exit 1
+  # Do not require file existence yet – let engine validate. But we already have absolute.
+
+  # Resolve binary BEFORE cd to cwd so workspace lookups use runner workspace
+  local bin
+  bin="$(resolve_binary)" || exit 1
+
+  # Now cd to cwd for engine execution (engine expects cwd)
+  cd "$cwd_abs"
+
+  # Build engine invocation array
+  local -a cmd
+  cmd=("$bin" "--config" "$config_abs" "--cwd" "$cwd_abs")
+
+  echo "🚀 ${bin} --config [REDACTED] --cwd [REDACTED]" >&2
+
+  local engine_status=0
+  "${cmd[@]}" || engine_status=$?
+
+  # Locate manifest after engine run (engine writes even on failure)
+  local manifest_path=""
+  local evidence_dir=""
+  manifest_path="$(find_manifest "$cwd_abs" 2>/dev/null || true)"
+  if [[ -n "$manifest_path" && -f "$manifest_path" ]]; then
+    # Ensure manifest_path is absolute
+    if [[ "$manifest_path" != /* ]]; then
+      manifest_path="$cwd_abs/$manifest_path"
+    fi
+    # Validate that manifest is inside cwd to prevent path escape
+    # Use python to check containment
+    local inside="true"
+    if command -v python3 >/dev/null 2>&1; then
+      inside="$(python3 -c 'import os,sys; cwd=os.path.realpath(sys.argv[1]); m=os.path.realpath(sys.argv[2]); print("true" if os.path.commonpath([cwd])==os.path.commonpath([cwd,m]) else "false")' "$cwd_abs" "$manifest_path" 2>/dev/null || echo "true")"
+    fi
+    if [[ "$inside" != "true" ]]; then
+      echo >&2 "⚠️ manifest escapes cwd, ignoring: $manifest_path"
+      manifest_path=""
+      evidence_dir=""
+    else
+      evidence_dir="$(dirname "$manifest_path")"
+      # Basic JSON validation without sourcing
+      if command -v python3 >/dev/null 2>&1; then
+        if ! python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$manifest_path" 2>/dev/null; then
+          echo >&2 "⚠️ result manifest is malformed JSON: $manifest_path"
+          # Keep path but will treat outcome as failure
+        fi
+      elif command -v jq >/dev/null 2>&1; then
+        if ! jq empty "$manifest_path" 2>/dev/null; then
+          echo >&2 "⚠️ result manifest is malformed JSON: $manifest_path"
+        fi
+      fi
+    fi
+  else
+    # No manifest found – keep empty, will infer from engine status
+    manifest_path=""
+    evidence_dir=""
+  fi
+
+  # Derive outputs from manifest or engine status
+  local outcome="" failed_phase="" sanitized_outcome="" sanitized_phase=""
+  if [[ -n "$manifest_path" && -f "$manifest_path" ]]; then
+    outcome="$(parse_manifest_field "$manifest_path" "outcome" 2>/dev/null || true)"
+    failed_phase="$(parse_manifest_field "$manifest_path" "phase" 2>/dev/null || true)"
+    # Manifest uses phase for failed phase; if outcome success, phase is cleanup but we output empty failed-phase
+    if [[ "$outcome" == "success" ]]; then
+      failed_phase=""
+    else
+      # If outcome not success/failure, fallback to engine status
+      if [[ "$outcome" != "success" && "$outcome" != "failure" ]]; then
+        if [[ $engine_status -eq 0 ]]; then
+          outcome="success"
+          failed_phase=""
+        else
+          outcome="failure"
+          # keep phase if present else fallback
+          if [[ -z "$failed_phase" ]]; then
+            failed_phase="unknown"
+          fi
+        fi
+      fi
+    fi
+  else
+    # No manifest – infer from engine status
+    if [[ $engine_status -eq 0 ]]; then
+      outcome="success"
+      failed_phase=""
+    else
+      outcome="failure"
+      failed_phase="unknown"
+    fi
+  fi
+
+  sanitized_outcome="$(sanitize_for_output "$outcome")"
+  sanitized_phase="$(sanitize_for_output "$failed_phase")"
+  local sanitized_evidence_dir=""
+  local sanitized_manifest=""
+  if [[ -n "$evidence_dir" ]]; then
+    sanitized_evidence_dir="$(sanitize_for_output "$evidence_dir")"
+  fi
+  if [[ -n "$manifest_path" ]]; then
+    sanitized_manifest="$(sanitize_for_output "$manifest_path")"
+  fi
+
+  # Determine artifact-name output based on policy and outcome
+  local artifact_output=""
+  if [[ "$policy" == "never" ]]; then
+    artifact_output=""
+  elif [[ "$policy" == "always" ]]; then
+    if [[ -n "$evidence_dir" && -d "$evidence_dir" ]]; then
+      artifact_output="$artifact_name_input"
+    else
+      # No evidence dir yet, still advertise name? but only if engine created evidence.
+      # Check if manifest exists implies evidence dir exists.
+      if [[ -n "$manifest_path" ]]; then
+        artifact_output="$artifact_name_input"
+      else
+        artifact_output=""
+      fi
+    fi
+  else # failure
+    if [[ "$sanitized_outcome" == "failure" ]]; then
+      if [[ -n "$evidence_dir" && -d "$evidence_dir" ]]; then
+        artifact_output="$artifact_name_input"
+      elif [[ -n "$manifest_path" ]]; then
+        artifact_output="$artifact_name_input"
+      else
+        # Still set artifact name if outcome failure, even if dir not found? Task says evidence upload is requested only after failure.
+        # We set name so upload step can attempt and warn if no files.
+        artifact_output="$artifact_name_input"
+      fi
+    else
+      artifact_output=""
+    fi
+  fi
+  artifact_output="$(sanitize_for_output "$artifact_output")"
+
+  # Write outputs to GITHUB_OUTPUT
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    {
+      printf "outcome=%s\n" "$sanitized_outcome"
+      printf "failed-phase=%s\n" "$sanitized_phase"
+      printf "evidence-directory=%s\n" "$sanitized_evidence_dir"
+      printf "result-manifest=%s\n" "$sanitized_manifest"
+      printf "artifact-name=%s\n" "$artifact_output"
+    } >> "$GITHUB_OUTPUT"
+  fi
+
+  # Also persist manifest path for summarize step via temp file (in case outputs not yet propagated to next step's env derivation before always()?)
+  # Write to runner temp for debugging; summarize.sh will prefer env COMPOSE_SANDBOX_RESULT_MANIFEST or fallback to finding.
+  if [[ -n "${RUNNER_TEMP:-}" && -n "$manifest_path" ]]; then
+    printf '%s' "$manifest_path" > "${RUNNER_TEMP}/compose-sandbox-manifest-path" 2>/dev/null || true
+  fi
+
+  # Preserve engine exit status
+  if [[ $engine_status -ne 0 ]]; then
+    exit $engine_status
+  fi
+}
+
+main "$@"

--- a/compose-sandbox/summarize.sh
+++ b/compose-sandbox/summarize.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Append redacted summary from engine result manifest.
+# Env vars are passed from action.yml; manifest is JSON validated without sourcing.
+
+manifest_from_env="${COMPOSE_SANDBOX_RESULT_MANIFEST:-}"
+manifest_from_input="${COMPOSE_SANDBOX_INPUT_RESULT_MANIFEST:-}"
+evidence_dir_env="${COMPOSE_SANDBOX_EVIDENCE_DIRECTORY:-${COMPOSE_SANDBOX_INPUT_EVIDENCE_DIRECTORY:-}}"
+outcome_env="${COMPOSE_SANDBOX_OUTCOME:-}"
+failed_phase_env="${COMPOSE_SANDBOX_FAILED_PHASE:-}"
+artifact_name_env="${COMPOSE_SANDBOX_INPUT_ARTIFACT_NAME:-}"
+
+manifest=""
+if [[ -n "$manifest_from_env" && -f "$manifest_from_env" ]]; then
+  manifest="$manifest_from_env"
+elif [[ -n "$manifest_from_input" && -f "$manifest_from_input" ]]; then
+  manifest="$manifest_from_input"
+elif [[ -n "${RUNNER_TEMP:-}" && -f "${RUNNER_TEMP}/compose-sandbox-manifest-path" ]]; then
+  candidate="$(cat "${RUNNER_TEMP}/compose-sandbox-manifest-path" 2>/dev/null || true)"
+  if [[ -n "$candidate" && -f "$candidate" ]]; then
+    manifest="$candidate"
+  fi
+fi
+
+# Fallback: try to locate via evidence dir
+if [[ -z "$manifest" && -n "$evidence_dir_env" && -f "$evidence_dir_env/result.json" ]]; then
+  manifest="$evidence_dir_env/result.json"
+fi
+if [[ -z "$manifest" && -n "${COMPOSE_SANDBOX_ACTION_PATH:-}" ]]; then
+  # No manifest – we still write a minimal summary from env outputs if available
+  :
+fi
+
+summary_file="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+# Helper to safely parse JSON field via python3
+parse_field() {
+  local path="$1"
+  local field="$2"
+  if [[ ! -f "$path" ]]; then echo ""; return 0; fi
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$path" "$field" <<'PY' 2>/dev/null || echo ""
+import json,sys
+p=sys.argv[1]; f=sys.argv[2]
+try:
+  d=json.load(open(p))
+  v=d.get(f,"")
+  if isinstance(v,str): print(v)
+  elif v is None: print("")
+  else: print(str(v) if not isinstance(v,(dict,list)) else "")
+except: print("")
+PY
+  else
+    echo ""
+  fi
+}
+
+sanitize() {
+  local v="$1"
+  v="$(printf '%s' "$v" | sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g' 2>/dev/null || printf '%s' "$v")"
+  v="${v//$'\n'/ }"
+  v="${v//$'\r'/ }"
+  if [[ ${#v} -gt 500 ]]; then v="${v:0:500}"; fi
+  printf '%s' "$v"
+}
+
+outcome=""
+phase=""
+evidence_dir=""
+manifest_path=""
+
+if [[ -n "$manifest" && -f "$manifest" ]]; then
+  if command -v python3 >/dev/null 2>&1; then
+    if ! python3 -c 'import json,sys; json.load(open(sys.argv[1]))' "$manifest" 2>/dev/null; then
+      # malformed
+      {
+        echo "### Compose sandbox result"
+        echo "- outcome: unknown (malformed manifest)"
+        echo "- manifest: \`$(sanitize "$manifest")\` (invalid JSON)"
+        if [[ -n "$evidence_dir_env" ]]; then echo "- evidence: \`$(sanitize "$evidence_dir_env")\`"; fi
+        if [[ -n "$artifact_name_env" ]]; then echo "- artifact: \`$(sanitize "$artifact_name_env")\` (upload policy may apply)"; fi
+        echo "- note: manifest is not valid JSON and was not evaluated as shell"
+      } >> "$summary_file"
+      exit 0
+    fi
+  fi
+  outcome="$(parse_field "$manifest" "outcome")"
+  phase="$(parse_field "$manifest" "phase")"
+  # outcome already sanitized via parse, but sanitize again
+  outcome="$(sanitize "$outcome")"
+  phase="$(sanitize "$phase")"
+  if [[ "$outcome" == "success" ]]; then
+    phase=""
+  fi
+  evidence_dir="$(dirname "$manifest")"
+  manifest_path="$manifest"
+else
+  # No manifest – use env outputs if available
+  outcome="$(sanitize "$outcome_env")"
+  phase="$(sanitize "$failed_phase_env")"
+  evidence_dir="$(sanitize "$evidence_dir_env")"
+  manifest_path=""
+  if [[ -z "$outcome" ]]; then
+    outcome="unknown"
+  fi
+fi
+
+# Never include raw config or env values
+# Summary contains only outcome, failed phase, artifact/evidence refs
+
+{
+  echo "### Compose sandbox result"
+  echo "- outcome: \`$(sanitize "${outcome:-unknown}")\`"
+  if [[ -n "$phase" ]]; then
+    echo "- failed phase: \`$(sanitize "$phase")\`"
+  else
+    if [[ "$outcome" == "failure" ]]; then
+      echo "- failed phase: \`unknown\`"
+    else
+      echo "- failed phase: \`\`"
+    fi
+  fi
+  if [[ -n "$manifest_path" ]]; then
+    echo "- evidence: \`$(sanitize "$manifest_path")\`"
+    if [[ -n "$evidence_dir" && "$evidence_dir" != "$manifest_path" ]]; then
+      echo "- evidence directory: \`$(sanitize "$evidence_dir")\`"
+    fi
+  elif [[ -n "$evidence_dir" ]]; then
+    echo "- evidence directory: \`$(sanitize "$evidence_dir")\`"
+  else
+    echo "- evidence directory: \`\`"
+  fi
+  if [[ -n "$artifact_name_env" ]]; then
+    # Only mention artifact name if it would be uploaded under current policy; but we mention configured name without implying upload occurred
+    echo "- artifact: \`$(sanitize "$artifact_name_env")\`"
+  fi
+} >> "$summary_file"

--- a/docs/tasks/20260825-180040-compose-sandbox-action.md
+++ b/docs/tasks/20260825-180040-compose-sandbox-action.md
@@ -1,0 +1,393 @@
+# Compose Sandbox GitHub Action
+
+Created: 2026-08-25 18:00:40
+
+Status: pending
+
+## Objective
+
+Add a reusable `compose-sandbox` composite GitHub Action that invokes the generic `repo-toolkit-compose-sandbox` lifecycle engine, uploads its evidence, writes a concise GitHub summary, and exposes stable outputs without reimplementing Docker Compose orchestration.
+
+The action must support workflows shaped like `_database-tools` integration Bats tests and `_vite-fastapi-postgres-template` Playwright sandbox tests. Repository-specific checkout, tools, package installation, matrix policy, service definitions, configuration, and test commands remain in consuming repositories.
+
+Required engine plan:
+
+- `projects/_repo-toolkit/docs/tasks/20260825-180040-compose-sandbox-runner.md`
+
+## Confirmed Reuse Opportunity
+
+The existing template-local action already centralizes start, wait, test, logs, and stop, but hardcodes Make commands and application endpoints. The database workflow independently implements the same lifecycle with raw Compose commands and richer readiness checks.
+
+The `_egose-actions` repository already provides the correct distribution model for reusable composite actions and already has a precedent for resolving a `repo-toolkit` CLI from an explicit input, workspace installation, `PATH`, asdf release, or package fallback.
+
+Primary evidence:
+
+- `README.md:1-29`
+- `confluence/action.yml:45-98`
+- `confluence/run.sh:47-194,239-282`
+- `.github/workflows/test-confluence.yml:18-75`
+- `.github/workflows/test-docker-build-push.yml:20-159`
+
+## Scope
+
+The first release must provide:
+
+- A `compose-sandbox/action.yml` composite action and focused wrapper script.
+- Inputs for project working directory, toolkit config path, toolkit binary override, and pinned toolkit installation version.
+- Optional artifact name, retention, and upload policy inputs.
+- Safe resolution and invocation of `repo-toolkit-compose-sandbox` without evaluating user inputs as shell source.
+- Artifact upload from the engine's evidence directory on failure by default, with an explicit always/never policy.
+- A concise GitHub step summary sourced from the engine's machine-readable result manifest.
+- Outputs for lifecycle outcome, failed phase, evidence directory, result manifest, and artifact name when uploaded.
+- Shell-level tests with fake binaries plus a real GitHub Actions fixture using Docker Compose.
+- Documentation examples corresponding to both intended consumer repositories.
+
+## Working Rules
+
+- Do not implement Compose startup, readiness polling, test execution, evidence generation, or cleanup in this repository. Those belong to `@repo-toolkit/compose-sandbox`.
+- Do not revert or rewrite unrelated worktree changes. Inspect `git status --short` before each task.
+- Pass action expressions into scripts through environment variables. Do not interpolate config paths, commands, or other caller-controlled strings into shell source.
+- Use arrays for CLI invocation. Do not construct a whitespace-delimited command string.
+- Default to an exact toolkit version tested with the action release. Do not default to `latest` and do not use an unpinned `npx` download.
+- Permit an explicit binary override for local development and fixture tests.
+- Do not print environment values, config contents, or toolkit command environment to logs or summaries.
+- Keep third-party action references pinned to full commit SHAs.
+- Add completion evidence to this file as tasks finish. Code without required verification is not complete.
+
+## Non-Goals
+
+- Creating a reusable workflow with checkout, runner, permissions, matrices, or package installation policy.
+- Installing Docker or supporting runners without Docker Compose v2.
+- Defining shared PostgreSQL, MongoDB, MinIO, Keycloak, API, or frontend services.
+- Accepting a multiline shell `script` input compatible with the current template-local action.
+- Preserving the current `make DAEMON=true up`, `make logs`, or `make down` interface.
+- Duplicating readiness endpoints as action inputs; probes belong in the toolkit config file.
+- Migrating consumers in the same change.
+- Refactoring the existing `confluence` action unless a small shared binary-resolution helper is proven safe and reduces duplication without changing its contract.
+
+## Baseline Verification
+
+Before implementation begins, record results for:
+
+```sh
+git status --short
+npm run actionlint
+npm run test:shell
+pre-commit run --all-files
+docker compose version
+```
+
+The task document was created from a clean worktree. If later baseline failures exist, record them before changing code and do not silently absorb unrelated remediation.
+
+Unit-style shell tests should fake toolkit/asdf behavior and not need Docker or network access. The GitHub workflow fixture must exercise a released toolkit version against real Docker Compose before the action is released.
+
+## Priorities
+
+- P0: Required to avoid mutable tool installation, shell injection, leaked sandbox resources, hidden failures, or secret exposure.
+- P1: Required for the initial action contract, outputs, artifact behavior, and automated tests.
+- P2: Documentation and consumer-shaped examples required before release.
+
+## Planned Action Contract
+
+Expected usage:
+
+```yaml
+- name: Run integration sandbox
+  id: sandbox
+  uses: egose/actions/compose-sandbox@<commit-sha>
+  with:
+    config: sandbox/ci-sandbox.mjs
+    artifact-name: integration-service-logs-${{ matrix.startup-attempt }}
+```
+
+Planned inputs:
+
+```text
+config                    required
+cwd                       default: github.workspace
+compose-sandbox-bin       optional explicit executable override
+repo-toolkit-version      exact version tested by this action release
+repo-toolkit-plugin-url   default: https://github.com/egose/repo-toolkit.git
+artifact-name             default: compose-sandbox-logs
+artifact-policy           failure | always | never; default: failure
+artifact-retention-days   optional
+```
+
+Planned outputs:
+
+```text
+outcome
+failed-phase
+evidence-directory
+result-manifest
+artifact-name
+```
+
+The action must consume the engine's result manifest rather than parse human log text. Exact optional output names may be refined, but changes to the config-file boundary, exact-version default, or thin-wrapper ownership require a recorded maintainer decision.
+
+## Execution Waves
+
+1. Action contract and local wrapper tests: ACTBOX-01 and ACTBOX-02.
+2. Artifact, summary, and failure behavior: ACTBOX-03.
+3. Real GitHub Actions integration and docs: ACTBOX-04.
+4. Independent final integration review: ACTBOX-05.
+
+ACTBOX-02 and later depend on the matching toolkit CLI/result-manifest contract. The action may be scaffolded against an explicit fake binary before the toolkit is published, but release verification must use an exact published version.
+
+## Detailed Tasks
+
+### Task ACTBOX-01: Define The Composite Action Contract
+
+Status: pending
+
+Priority: P1
+
+Suggested agent: GitHub Actions contract engineer
+
+Dependencies: toolkit CSBOX-02 contract reviewed; implementation may use a fake binary
+
+Primary ownership:
+
+- `compose-sandbox/action.yml`
+- `compose-sandbox/README.md`
+- root `README.md` module entry
+- initial `tests/fixtures/compose-sandbox/`
+
+Finding:
+
+No shared sandbox action exists. The template-local action's single `script` input and hardcoded Make/endpoints cannot represent the database sandbox safely or generically.
+
+References:
+
+- `README.md:5-19`
+- `confluence/action.yml:45-98`
+
+Implementation requirements:
+
+1. Define the planned inputs and outputs with accurate descriptions, required/default behavior, and no multiline shell command input.
+2. Pass every caller-controlled value to the wrapper through environment variables.
+3. Keep GitHub-specific artifact and summary steps separate from the engine invocation step so they can run under `always()` as required.
+4. Document that the caller must check out source, install project dependencies, and provide a valid toolkit config and Docker Compose v2 runner.
+5. Add both database-shaped and template-shaped usage examples without claiming consumer migration has happened.
+
+Acceptance criteria:
+
+- `actionlint compose-sandbox/action.yml` passes through the repository's actionlint command.
+- The root module table links to the action README.
+- Documentation clearly separates action, engine, and consumer responsibilities.
+- No action input is evaluated as shell source.
+
+### Task ACTBOX-02: Resolve And Invoke The Pinned Toolkit CLI Safely
+
+Status: pending
+
+Priority: P0
+
+Suggested agent: shell and supply-chain engineer
+
+Dependencies: ACTBOX-01; toolkit CSBOX-06 complete; exact compatible toolkit release available before completion
+
+Primary ownership:
+
+- `compose-sandbox/run.sh`
+- `tests/test-compose-sandbox.sh`
+- focused fake executables under `tests/fixtures/compose-sandbox/`
+- `package.json` test script registration if needed
+
+Finding:
+
+The wrapper needs zero-setup operation while retaining reproducibility. The existing Confluence wrapper demonstrates explicit/workspace/PATH/asdf/package resolution, but its default `latest` behavior and whitespace-delimited argument construction must not be copied into the new action.
+
+References:
+
+- `confluence/run.sh:47-194,239-282`
+- `confluence/action.yml:49-72`
+- `tests/test-confluence.sh:1-145`
+Implementation requirements:
+
+1. Resolve the CLI in this order: explicit override, consumer workspace `node_modules/.bin`, action/PATH installation, exact-version asdf installation, exact-version package fallback if retained.
+2. Validate version input syntax and ensure every network installation path uses that exact version. Reject `latest`, empty resolved versions, and mutable package fallback.
+3. Invoke the binary and flags with a Bash array, passing absolute validated `cwd` and config paths without `eval`, `bash -c`, or command-string expansion.
+4. Preserve the toolkit's exit status while making its result manifest location available to later composite steps.
+5. Test paths containing spaces and shell metacharacters, missing executables, failed installation, toolkit failure, and successful invocation. Assert that values are passed literally and not executed.
+6. Avoid broad refactoring of `confluence/run.sh`; record a follow-up if a shared resolver becomes independently worthwhile.
+
+Acceptance criteria:
+
+- Shell tests prove explicit, workspace, PATH, asdf, and any package fallback resolution use the expected exact executable/version.
+- A malicious-looking config/cwd value is passed as one literal argument and cannot create a marker file.
+- Toolkit nonzero status remains nonzero and its result manifest remains available when produced.
+- `npm run test:shell` passes.
+
+### Task ACTBOX-03: Upload Evidence And Publish Redacted Outputs
+
+Status: pending
+
+Priority: P0
+
+Suggested agent: CI failure-observability engineer
+
+Dependencies: ACTBOX-02; toolkit CSBOX-05 result-manifest contract stable
+
+Primary ownership:
+
+- `compose-sandbox/action.yml`
+- small focused helper under `compose-sandbox/` if needed
+- `tests/test-compose-sandbox.sh`
+
+Finding:
+
+Both reference implementations need failure logs, but artifact naming and capture policy differ. The action should consume already-bounded engine evidence instead of running Compose commands after the engine has cleaned up.
+
+References:
+
+- `docker-build-push/action.yml:315-336`
+
+Implementation requirements:
+
+1. Read and validate the toolkit's machine-readable result manifest without sourcing or evaluating it as shell.
+2. Set declared outputs and append a concise step summary containing outcome, failed phase, and artifact/evidence references only.
+3. Upload the evidence directory according to `failure`, `always`, or `never`; use the pinned `actions/upload-artifact` commit already established in the repository unless intentionally upgraded everywhere by separate work.
+4. Preserve action failure when the toolkit fails after artifact and summary steps execute. Artifact upload failure must be visible and must not turn a failed sandbox into success.
+5. Reject artifact names or manifest paths that violate GitHub/action path constraints, and never include config environment values or raw command environments in outputs or summary.
+
+Acceptance criteria:
+
+- Success and failure fixtures set all applicable outputs consistently.
+- Failure-policy tests show evidence upload is requested only after failure; always/never behave as documented.
+- A malformed, missing, escaping, or secret-bearing manifest is handled without evaluating content or exposing secrets.
+- The original sandbox failure remains the action outcome after evidence handling.
+- `npm run actionlint` and `npm run test:shell` pass.
+
+### Task ACTBOX-04: Add Real Compose CI And Consumer Documentation
+
+Status: pending
+
+Priority: P2
+
+Suggested agent: GitHub Actions integration engineer
+
+Dependencies: ACTBOX-03; exact toolkit version published after CSBOX-07
+
+Primary ownership:
+
+- `.github/workflows/test-compose-sandbox.yml`
+- `tests/fixtures/compose-sandbox/`
+- `compose-sandbox/README.md`
+- root validation paths/scripts as needed
+
+Finding:
+
+Shell fakes can validate argument and installation behavior but cannot prove composite `if: always()` behavior, artifact upload, Docker cleanup, or compatibility with the published toolkit artifact on a GitHub-hosted runner.
+
+References:
+
+- `.github/workflows/test-confluence.yml:18-75`
+- `.github/workflows/test-docker-build-push.yml:88-159`
+- `.github/workflows/actionlint.yml:3-19`
+- `projects/_repo-toolkit/docs/tasks/20260825-180040-compose-sandbox-runner.md`
+
+Implementation requirements:
+
+1. Add a minimal real-Compose fixture with a healthy long-running service, a successful one-shot service, and a deterministic test command.
+2. Exercise success and forced-test-failure jobs through `uses: ./compose-sandbox`; verify outputs, summaries where observable, artifact creation, and no leaked containers/networks/volumes.
+3. Install or resolve the exact published toolkit version declared as the action default. Do not test release behavior only against an unpublished sibling checkout.
+4. Add workflow path filters for action, wrapper, fixture, and workflow changes.
+5. Complete docs with pinned action usage and configurations matching the database mixed-probe sandbox and template HTTP-probe sandbox.
+6. Document migration requirements: use `docker compose`, move repository-specific readiness/test behavior into toolkit config, and retain existing checkout/setup/matrix steps.
+
+Acceptance criteria:
+
+- GitHub-hosted success and expected-failure fixture jobs pass their assertions.
+- Failure evidence is downloadable under the configured artifact name.
+- Post-run checks find no fixture Compose resources.
+- Documentation examples contain no mutable action or toolkit references.
+- `npm run actionlint`, `npm run test:shell`, and `pre-commit run --all-files` pass.
+
+### Task ACTBOX-05: Perform Independent Action Integration Review
+
+Status: pending
+
+Priority: P0
+
+Suggested agent: independent GitHub Actions and supply-chain reviewer
+
+Dependencies: ACTBOX-04
+
+Primary ownership:
+
+- review-only across `compose-sandbox/`, tests, workflow, and docs
+- fixes limited to review findings
+- this task document's completion evidence
+
+Finding:
+
+The final behavior crosses shell quoting, executable resolution, mutable dependency prevention, composite step conditions, artifact handling, and engine failure semantics. These boundaries require review independent of the main implementation.
+
+References:
+
+- all ACTBOX tasks and acceptance criteria
+- `projects/_repo-toolkit/docs/tasks/20260825-180040-compose-sandbox-runner.md`
+- `.pre-commit-config.yaml:1-43`
+
+Implementation requirements:
+
+1. Verify every action input and toolkit-derived value remains data rather than shell source.
+2. Verify every installation path resolves the documented exact toolkit version and third-party actions use commit SHAs.
+3. Verify toolkit failure, malformed manifest, artifact failure, cancellation, and action timeout cannot report false success or skip engine cleanup.
+4. Verify docs, inputs, outputs, summary, result manifest, and published toolkit behavior agree.
+5. Run shell, actionlint, pre-commit, and real-Compose workflow checks and record exact evidence.
+
+Acceptance criteria:
+
+- `npm run actionlint`, `npm run test:shell`, `npm run pre-commit`, and `git diff --check` pass.
+- Required GitHub workflow checks pass for success and expected-failure fixtures.
+- No mutable toolkit resolution or shell evaluation remains.
+- No generated credentials, tokens, environment values, or unbounded raw logs enter outputs, summaries, or committed fixtures.
+- Any deferred issue records rationale, owner, and residual risk.
+
+## Dependency And Parallelization Guidance
+
+| Wave | Tasks | Parallelism |
+| --- | --- | --- |
+| 1 | ACTBOX-01, ACTBOX-02 | Sequential around `action.yml` and wrapper contract; fake-binary test design may proceed while toolkit is implemented. |
+| 2 | ACTBOX-03 | Starts after engine result-manifest behavior stabilizes. |
+| 3 | ACTBOX-04 | Starts only after an exact toolkit version is published. |
+| 4 | ACTBOX-05 | Independent and last. |
+
+Shared hotspots are `compose-sandbox/action.yml`, `compose-sandbox/run.sh`, `tests/test-compose-sandbox.sh`, `package.json`, and the action README. Keep one owner at a time. Real Docker workflows must use unique Compose project names and artifact names per job.
+
+Cross-repository dependency:
+
+```text
+CSBOX-02 -> ACTBOX-01
+CSBOX-05 -> ACTBOX-03
+CSBOX-07 + published version -> ACTBOX-04
+ACTBOX-04 -> ACTBOX-05
+```
+
+## Deferred Decisions
+
+- Consumer migrations are deferred to separate task files in `_database-tools` and `_vite-fastapi-postgres-template`.
+- A reusable workflow is deferred because runner versions, checkout/ref evidence, tool installation, permissions, matrices, and test policy remain repository-specific.
+- A shared binary-resolution shell library is deferred unless implementation proves it can improve both Compose and Confluence actions without changing either public contract.
+- Supporting a user-provided multiline shell command is deliberately deferred; repository test commands belong in the toolkit's structured config.
+
+ACTBOX-04 is blocked until CSBOX-07 identifies an exact published toolkit version. No maintainer decision blocks ACTBOX-01 design work.
+
+## Toolkit Release Prerequisite (recorded by CSBOX-07 – 2026-08-25)
+
+- Independent review completed in `repo-toolkit` at `projects/_repo-toolkit/docs/tasks/20260825-180040-compose-sandbox-runner.md` (Status: completed).
+- Verified workspace state: `pnpm lint`/`typecheck`/`build`/`test` pass, `pnpm --filter @repo-toolkit/publish-packages test` passes (78 tests), `pnpm --filter @repo-toolkit/compose-sandbox test` passes (10 files, 134 tests), no tracked `dist/`, `git diff --check` passes; real-Compose fixtures skipped explicitly due to Docker unavailable in WSL (skip logic verified, requires GitHub-hosted Linux run for non-skipped proof).
+- Current toolkit root version: `0.6.0` (`projects/_repo-toolkit/package.json`). `@repo-toolkit/compose-sandbox` is at `0.0.0-PLACEHOLDER` awaiting publish.
+- Required publish step before ACTBOX-04/real-action CI: `pnpm release` (release-it bumps `VERSION` + root `package.json` via `.release-it.json`) then publish via `pnpm publish-packages -- --version <tag>` (e.g. `v0.7.0` or as decided) which rewrites placeholder to target version and publishes the tarball consumed by `release-artifact` asdf. ACTBOX-02/04 must pin the resulting exact version as `repo-toolkit-version` in `compose-sandbox/action.yml`.
+
+## Definition Of Done
+
+- All ACTBOX tasks are completed with verification evidence.
+- `compose-sandbox` appears in the root module list and has complete input/output/security documentation.
+- The action delegates all lifecycle behavior to the toolkit and contains no service-specific readiness or Compose teardown logic.
+- Every remote dependency and toolkit installation is immutable or exact-versioned.
+- Fake shell tests and real GitHub Compose tests cover success, failure, evidence, and no-leak behavior.
+- Outputs and summaries are redacted, stable, and derived from the validated engine manifest.
+- Separate consumer migration tasks can adopt the action without redesigning its public contract.

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "pre-commit": "pre-commit run --all-files",
     "precommit": "npm run pre-commit",
     "lint": "npm run actionlint && npm run pre-commit",
-    "test:shell": "bash tests/test-confluence.sh && bash tests/test-install-packages.sh && bash tests/test-release-tag.sh",
+    "test:shell": "bash tests/test-confluence.sh && bash tests/test-compose-sandbox.sh && bash tests/test-install-packages.sh && bash tests/test-release-tag.sh",
     "release": "release-it",
     "changelog": "repo-toolkit-changelog"
   },
@@ -33,8 +33,9 @@
     "@commitlint/config-conventional": "^21.2.2",
     "@commitlint/format": "^21.2.2",
     "@release-it/bumper": "^8.0.0",
-    "@repo-toolkit/changelog": "^0.13.0",
-    "@repo-toolkit/confluence": "^0.13.0",
+    "@repo-toolkit/changelog": "^0.17.0",
+    "@repo-toolkit/compose-sandbox": "^0.17.0",
+    "@repo-toolkit/confluence": "^0.17.0",
     "release-it": "^21.0.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,11 +21,14 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0(release-it@21.0.2(@types/node@25.6.0))
       '@repo-toolkit/changelog':
-        specifier: ^0.13.0
-        version: 0.13.0
+        specifier: ^0.17.0
+        version: 0.17.0
+      '@repo-toolkit/compose-sandbox':
+        specifier: ^0.17.0
+        version: 0.17.0
       '@repo-toolkit/confluence':
-        specifier: ^0.13.0
-        version: 0.13.0
+        specifier: ^0.17.0
+        version: 0.17.0
       release-it:
         specifier: ^21.0.2
         version: 21.0.2(@types/node@25.6.0)
@@ -366,18 +369,23 @@ packages:
     peerDependencies:
       release-it: ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0
 
-  '@repo-toolkit/changelog@0.13.0':
-    resolution: {integrity: sha512-RHNK9jB/ojqzRpZ6h3v8vfa6q0xRg0GK3LvpX3/IUHwvn7VnWJRNUbsNK8E0/A7Aaz8Wfx9/mhPv+QuSf2c1zw==}
+  '@repo-toolkit/changelog@0.17.0':
+    resolution: {integrity: sha512-QyffVnvWngfGIdsVyBld0/12NdKl2MM56mmuNyD3VV1I8oYjFQIawKmF5LNZyaOJEdODhAdYspiv5qm5PmWNdQ==}
     engines: {node: '>=20'}
     hasBin: true
 
-  '@repo-toolkit/confluence@0.13.0':
-    resolution: {integrity: sha512-wB2VUS1/ilIsaEcZGXFz8KHdtqaO+6xrI92cEWYfXf8jkK7n2wTLSykhykbs//mHZY5oHpdGrVuYyJkGsRDKtg==}
+  '@repo-toolkit/compose-sandbox@0.17.0':
+    resolution: {integrity: sha512-JGdyxnFTMNtH5sEuQmaZVaHRHydUEHC99n/TC/5tkkmvyyYQ8E1rfa7OQaS23FGaGk2VugAMJuaFDCN68+VWdA==}
     engines: {node: '>=20'}
     hasBin: true
 
-  '@repo-toolkit/publish-package@0.13.0':
-    resolution: {integrity: sha512-0OBO0MwVqy6Gks1pgpRo9MUN+cPhCZT1OQ/0Gm3vdTk8ZMcX3mH5wT6LS+yvAH+41onicxhY6bZkOC+IKduuGg==}
+  '@repo-toolkit/confluence@0.17.0':
+    resolution: {integrity: sha512-abXPLweTLiVprmvw9zyCZJj82STRLd6ce5pyzUQkdvrYY1zubo2AwWtwmZBIojttasl2aN8WRUhpKec323HN4w==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  '@repo-toolkit/publish-package@0.17.0':
+    resolution: {integrity: sha512-GG3hHNQoq+GteBnujoXJyaGHRi21FZarAQKnajWb6T7WAOOeUmlmPbkJUaosgq6fYX/JeiGprRdLnjmW2s4ijg==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -1657,19 +1665,23 @@ snapshots:
       release-it: 21.0.2(@types/node@25.6.0)
       semver: 7.8.5
 
-  '@repo-toolkit/changelog@0.13.0':
+  '@repo-toolkit/changelog@0.17.0':
     dependencies:
-      '@repo-toolkit/publish-package': 0.13.0
+      '@repo-toolkit/publish-package': 0.17.0
       conventional-changelog: 7.2.1
       conventional-changelog-conventionalcommits: 9.3.1
     transitivePeerDependencies:
       - conventional-commits-filter
 
-  '@repo-toolkit/confluence@0.13.0':
+  '@repo-toolkit/compose-sandbox@0.17.0':
     dependencies:
-      '@repo-toolkit/publish-package': 0.13.0
+      '@repo-toolkit/publish-package': 0.17.0
 
-  '@repo-toolkit/publish-package@0.13.0':
+  '@repo-toolkit/confluence@0.17.0':
+    dependencies:
+      '@repo-toolkit/publish-package': 0.17.0
+
+  '@repo-toolkit/publish-package@0.17.0':
     dependencies:
       '@clack/prompts': 1.7.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,6 +3,7 @@
 # gate (e.g. freshly-released @repo-toolkit/* packages that the action needs
 # immediately). Re-run `pnpm install` to refresh; do not format/sort by hand.
 minimumReleaseAgeExclude:
-- '@repo-toolkit/confluence@0.8.0 || 0.9.0'
-- '@repo-toolkit/publish-package@0.8.0 || 0.9.0'
-- '@repo-toolkit/changelog@0.9.0'
+- '@repo-toolkit/confluence@0.17.0'
+- '@repo-toolkit/publish-package@0.17.0'
+- '@repo-toolkit/changelog@0.17.0'
+- '@repo-toolkit/compose-sandbox@0.17.0'

--- a/tests/fixtures/compose-sandbox/README.md
+++ b/tests/fixtures/compose-sandbox/README.md
@@ -1,0 +1,15 @@
+# compose-sandbox fixtures
+
+Minimal real-Compose fixtures for GitHub-hosted integration tests.
+
+- `docker-compose.yml` – long-running `web` (nginx:alpine) + successful one-shot `init` (alpine:3.18)
+- `success.mjs` – HTTP + service-completed readiness, `node -e process.exit(0)` test, evidence `always`
+- `failure.mjs` – same topology but `node -e process.exit(2)` forces test failure to exercise artifact upload and cleanup
+
+Both fixtures use distinct `projectName` values (`cs-test-success`, `cs-test-failure`) and bounded timeouts (60s startup/readiness, 30s test/cleanup) so parallel jobs do not leak containers/networks.
+
+The workflow `test-compose-sandbox.yml` exercises both success and forced-failure paths through `uses: ./compose-sandbox` with the exact published `@repo-toolkit/compose-sandbox@0.17.0`.
+
+Consumer-shaped references:
+
+- Database-shaped mixed probes (TCP/HTTP/one-shot + Bats) and template-shaped HTTP probes (Playwright) are documented in `compose-sandbox/README.md` and the engine docs; these fixtures prove the thin-wrapper + engine contract without requiring those full consumer repos.

--- a/tests/fixtures/compose-sandbox/docker-compose.yml
+++ b/tests/fixtures/compose-sandbox/docker-compose.yml
@@ -1,0 +1,10 @@
+services:
+  web:
+    image: nginx:alpine
+    ports:
+    - 127.0.0.1:8000:80
+    # Keep lightweight; no healthcheck – readiness is via HTTP probe
+  init:
+    image: alpine:3.18
+    command: [sh, -c, echo init done && exit 0]
+    restart: no

--- a/tests/fixtures/compose-sandbox/failure.mjs
+++ b/tests/fixtures/compose-sandbox/failure.mjs
@@ -1,0 +1,15 @@
+export default {
+  cwd: '.',
+  compose: {
+    files: ['docker-compose.yml'],
+    projectName: 'cs-test-failure',
+  },
+  readiness: [
+    { type: 'http', url: 'http://127.0.0.1:8000/' },
+    { type: 'service-completed', service: 'init' },
+  ],
+  test: { executable: 'node', args: ['-e', 'process.exit(2)'] },
+  evidence: { directory: '.compose-sandbox-logs', capture: 'always' },
+  cleanup: { volumes: true, removeOrphans: true },
+  timeouts: { startupMs: 60000, readinessMs: 60000, testMs: 30000, cleanupMs: 30000 },
+};

--- a/tests/fixtures/compose-sandbox/success.mjs
+++ b/tests/fixtures/compose-sandbox/success.mjs
@@ -1,0 +1,15 @@
+export default {
+  cwd: '.',
+  compose: {
+    files: ['docker-compose.yml'],
+    projectName: 'cs-test-success',
+  },
+  readiness: [
+    { type: 'http', url: 'http://127.0.0.1:8000/' },
+    { type: 'service-completed', service: 'init' },
+  ],
+  test: { executable: 'node', args: ['-e', 'process.exit(0)'] },
+  evidence: { directory: '.compose-sandbox-logs', capture: 'always' },
+  cleanup: { volumes: true, removeOrphans: true },
+  timeouts: { startupMs: 60000, readinessMs: 60000, testMs: 30000, cleanupMs: 30000 },
+};

--- a/tests/test-compose-sandbox.sh
+++ b/tests/test-compose-sandbox.sh
@@ -1,0 +1,817 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+workspace_root="$(mktemp -d)"
+trap 'rm -rf "$workspace_root"' EXIT
+
+# Shared helpers
+assert_eq() {
+  local got="$1"
+  local want="$2"
+  local msg="$3"
+  if [[ "$got" != "$want" ]]; then
+    echo "FAIL $msg: got '$got' want '$want'" >&2
+    exit 1
+  fi
+}
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  local msg="$3"
+  if ! grep -Fq -- "$needle" "$file"; then
+    echo "FAIL $msg: missing '$needle' in $file" >&2
+    cat "$file" >&2 || true
+    exit 1
+  fi
+}
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  local msg="$3"
+  if grep -Fq -- "$needle" "$file" 2>/dev/null; then
+    echo "FAIL $msg: unexpected '$needle' in $file" >&2
+    cat "$file" >&2 || true
+    exit 1
+  fi
+}
+assert_file_exists() {
+  local f="$1"
+  local msg="$2"
+  if [[ ! -e "$f" ]]; then
+    echo "FAIL $msg: missing $f" >&2
+    exit 1
+  fi
+}
+assert_file_not_exists() {
+  local f="$1"
+  local msg="$2"
+  if [[ -e "$f" ]]; then
+    echo "FAIL $msg: should not exist $f" >&2
+    exit 1
+  fi
+}
+
+# -------------------------------------------------------------------
+# Test helpers: create fake binary that logs args and optionally creates manifest
+# -------------------------------------------------------------------
+make_fake_bin() {
+  local path="$1"
+  local mode="$2" # success|fail
+  local evidence_dir_name="${3:-.compose-sandbox-logs}"
+  cat > "$path" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+log_file="\${FAKE_CLI_LOG:-/tmp/cli.log}"
+echo "\$*" >> "\$log_file"
+# Also log each arg separately for injection check
+printf 'ARGS:%s\n' "\$*" >> "\$log_file"
+for a in "\$@"; do
+  printf 'ARG:%s\n' "\$a" >> "\$log_file"
+done
+# Parse --cwd and --config from args
+cwd_val=""
+config_val=""
+args=("\$@")
+for i in "\${!args[@]}"; do
+  if [[ "\${args[i]}" == "--cwd" ]]; then
+    cwd_val="\${args[i+1]:-}"
+  fi
+  if [[ "\${args[i]}" == "--config" ]]; then
+    config_val="\${args[i+1]:-}"
+  fi
+done
+if [[ -n "\$cwd_val" && -n "$evidence_dir_name" ]]; then
+  mkdir -p "\$cwd_val/$evidence_dir_name"
+  if [[ "$mode" == "success" ]]; then
+    cat > "\$cwd_val/$evidence_dir_name/result.json" <<JSON
+{"phase":"cleanup","outcome":"success","timings":{},"evidenceFiles":["ps.json","logs.txt","result.json"],"errors":{}}
+JSON
+  else
+    cat > "\$cwd_val/$evidence_dir_name/result.json" <<JSON
+{"phase":"test","outcome":"failure","timings":{},"evidenceFiles":["ps.json","logs.txt","result.json"],"errors":{"primary":"test command failed with exitCode 2"}}
+JSON
+  fi
+  echo "ps" > "\$cwd_val/$evidence_dir_name/ps.json" || true
+  echo "logs" > "\$cwd_val/$evidence_dir_name/logs.txt" || true
+fi
+if [[ "$mode" == "fail" ]]; then
+  exit 2
+fi
+exit 0
+EOF
+  chmod 755 "$path"
+}
+
+make_fake_asdf() {
+  local bin_dir="$1"
+  local asdf_data_dir="$2"
+  cat > "${bin_dir}/asdf" <<'EOS'
+#!/usr/bin/env bash
+set -euo pipefail
+log_file="${FAKE_ASDF_LOG:?}"
+asdf_data_dir="${ASDF_DATA_DIR:?}"
+cli_log="${FAKE_CLI_LOG:-/tmp/cli.log}"
+case "${1:-}" in
+  plugin)
+    case "${2:-}" in
+      list) exit 0 ;;
+      add) printf 'plugin add %s %s\n' "${3:-}" "${4:-}" >> "$log_file"; exit 0 ;;
+    esac
+    ;;
+  list) exit 0 ;;
+  install)
+    if [[ "${2:-}" == "repo-toolkit" ]]; then
+      printf 'install %s\n' "${3:-}" >> "$log_file"
+      # only allow pinned version 0.17.0 for compose tests
+      if [[ "${3:-}" != "0.17.0" ]]; then
+        printf 'unexpected version %s\n' "${3:-}" >&2
+        exit 1
+      fi
+      install_dir="${asdf_data_dir}/installs/repo-toolkit/${3}/bin"
+      mkdir -p "$install_dir"
+      cat > "${install_dir}/repo-toolkit-compose-sandbox" <<'CLI'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "${FAKE_CLI_LOG:?}"
+for a in "$@"; do printf 'ARG:%s\n' "$a" >> "${FAKE_CLI_LOG:?}"; done
+cwd_val=""
+args=("$@")
+for i in "${!args[@]}"; do if [[ "${args[i]}" == "--cwd" ]]; then cwd_val="${args[i+1]:-}"; fi; done
+if [[ -n "$cwd_val" ]]; then mkdir -p "$cwd_val/.compose-sandbox-logs"; cat > "$cwd_val/.compose-sandbox-logs/result.json" <<'JSON'
+{"phase":"cleanup","outcome":"success","timings":{},"evidenceFiles":["result.json"],"errors":{}}
+JSON
+fi
+CLI
+      chmod 755 "${install_dir}/repo-toolkit-compose-sandbox"
+      exit 0
+    fi
+    ;;
+  set) printf 'set %s %s %s\n' "${2:-}" "${3:-}" "${4:-}" >> "$log_file"; exit 0 ;;
+  reshim) printf 'reshim %s\n' "${2:-all}" >> "$log_file"; exit 0 ;;
+  which)
+    if [[ "${2:-}" == "repo-toolkit-compose-sandbox" ]]; then
+      if [[ -x "${asdf_data_dir}/installs/repo-toolkit/0.17.0/bin/repo-toolkit-compose-sandbox" ]]; then
+        printf '%s\n' "${asdf_data_dir}/installs/repo-toolkit/0.17.0/bin/repo-toolkit-compose-sandbox"
+        exit 0
+      fi
+      exit 1
+    fi
+    ;;
+esac
+printf 'unexpected asdf invocation: %s\n' "$*" >&2
+exit 1
+EOS
+  chmod 755 "${bin_dir}/asdf"
+  for tool in jq node python3; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      cat > "${bin_dir}/${tool}" <<'T'
+#!/usr/bin/env bash
+exit 0
+T
+      chmod 755 "${bin_dir}/${tool}"
+    else
+      # ensure bin_dir has wrapper that delegates to system if not mocked separately
+      :
+    fi
+  done
+  # ensure jq/node exist in bin_dir for asdf install checks – create pass-through if missing
+  for t in jq node; do
+    if [[ ! -x "${bin_dir}/${t}" ]]; then
+      cat > "${bin_dir}/${t}" <<EOS
+#!/usr/bin/env bash
+exec "$(command -v $t)" "\$@"
+EOS
+      chmod 755 "${bin_dir}/${t}"
+    fi
+  done
+}
+
+run_sandbox() {
+  # Args: workspace, cwd_input, config_input, extra_env...
+  local ws="$1"
+  local cwd_input="$2"
+  local config_input="$3"
+  shift 3
+  local extra_env=("$@")
+  local out="${ws}/out.log"
+  local err="${ws}/err.log"
+  local gh_out="${ws}/github_output"
+  local gh_summary="${ws}/github_summary"
+  : > "$gh_out"
+  : > "$gh_summary"
+  mkdir -p "$(dirname "$config_input" 2>/dev/null || true)" 2>/dev/null || true
+  # Create config file path relative to cwd if needed
+  local cwd_abs
+  if [[ "$cwd_input" == /* ]]; then cwd_abs="$cwd_input"; else cwd_abs="${ws}/${cwd_input}"; fi
+  mkdir -p "$cwd_abs"
+  local cfg_path
+  if [[ "$config_input" == /* ]]; then cfg_path="$config_input"; else cfg_path="$cwd_abs/$config_input"; fi
+  mkdir -p "$(dirname "$cfg_path")"
+  touch "$cfg_path" 2>/dev/null || true
+
+  # Build env array
+  local env_vars=(
+    "GITHUB_WORKSPACE=$ws"
+    "GITHUB_OUTPUT=$gh_out"
+    "GITHUB_STEP_SUMMARY=$gh_summary"
+    "COMPOSE_SANDBOX_ACTION_PATH=${repo_root}/compose-sandbox"
+    "COMPOSE_SANDBOX_INPUT_CONFIG=$config_input"
+    "COMPOSE_SANDBOX_INPUT_CWD=$cwd_input"
+    "RUNNER_TEMP=$ws"
+  )
+  for e in "${extra_env[@]}"; do env_vars+=("$e"); done
+
+  local status=0
+  set +e
+  env "${env_vars[@]}" bash "${repo_root}/compose-sandbox/run.sh" >"$out" 2>"$err" || status=$?
+  set -e
+  echo "$status" > "${ws}/exit_code"
+  cp "$gh_out" "${ws}/gh_out_copy" 2>/dev/null || true
+  cp "$gh_summary" "${ws}/gh_summary_copy" 2>/dev/null || true
+}
+
+get_output() {
+  local ws="$1"
+  local key="$2"
+  grep -E "^${key}=" "${ws}/gh_out_copy" 2>/dev/null | head -n 1 | cut -d= -f2- || echo ""
+}
+
+# -------------------------------------------------------------------
+# Test 1: explicit override
+# -------------------------------------------------------------------
+test_explicit() {
+  local ws
+  ws="$(mktemp -d -p "$workspace_root")"
+  local bin_dir="${ws}/bin"
+  mkdir -p "$bin_dir"
+  local asdf_data="${ws}/asdf"
+  mkdir -p "$asdf_data/shims"
+  local cli_log="${ws}/cli.log"
+  local asdf_log="${ws}/asdf.log"
+  : > "$cli_log"; : > "$asdf_log"
+  mkdir -p "${ws}/work"
+  local explicit_bin="${ws}/my-bin/repo-toolkit-compose-sandbox"
+  mkdir -p "$(dirname "$explicit_bin")"
+  make_fake_bin "$explicit_bin" "success"
+  make_fake_asdf "$bin_dir" "$asdf_data"
+  export PATH="${bin_dir}:/usr/bin:/bin"
+  export ASDF_DATA_DIR="$asdf_data"
+  export FAKE_ASDF_LOG="$asdf_log"
+  export FAKE_CLI_LOG="$cli_log"
+
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$explicit_bin" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.17.0"
+
+  local code
+  code="$(cat "$ws/exit_code")"
+  assert_eq "$code" "0" "explicit: exit code"
+  assert_contains "$cli_log" "--config" "explicit: cli invoked"
+  # Ensure asdf install not triggered
+  assert_not_contains "$asdf_log" "install" "explicit: should not install via asdf"
+  local outcome
+  outcome="$(get_output "$ws" "outcome")"
+  assert_eq "$outcome" "success" "explicit: outcome"
+  rm -rf "$ws"
+  echo "✓ explicit override"
+}
+
+# -------------------------------------------------------------------
+# Test 2: workspace node_modules/.bin
+# -------------------------------------------------------------------
+test_workspace() {
+  local ws
+  ws="$(mktemp -d -p "$workspace_root")"
+  local bin_dir="${ws}/bin"
+  mkdir -p "$bin_dir"
+  local asdf_data="${ws}/asdf"
+  mkdir -p "$asdf_data/shims"
+  local cli_log="${ws}/cli.log"
+  local asdf_log="${ws}/asdf.log"
+  : > "$cli_log"; : > "$asdf_log"
+  mkdir -p "${ws}/work"
+  mkdir -p "${ws}/node_modules/.bin"
+  local ws_bin="${ws}/node_modules/.bin/repo-toolkit-compose-sandbox"
+  make_fake_bin "$ws_bin" "success"
+  make_fake_asdf "$bin_dir" "$asdf_data"
+  export PATH="${bin_dir}:/usr/bin:/bin"
+  export ASDF_DATA_DIR="$asdf_data"
+  export FAKE_ASDF_LOG="$asdf_log"
+  export FAKE_CLI_LOG="$cli_log"
+
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.17.0"
+
+  local code
+  code="$(cat "$ws/exit_code")"
+  assert_eq "$code" "0" "workspace: exit"
+  assert_contains "$cli_log" "--config" "workspace: cli invoked"
+  assert_not_contains "$asdf_log" "install" "workspace: no asdf install"
+  rm -rf "$ws"
+  echo "✓ workspace bin"
+}
+
+# -------------------------------------------------------------------
+# Test 3: PATH lookup
+# -------------------------------------------------------------------
+test_path() {
+  local ws
+  ws="$(mktemp -d -p "$workspace_root")"
+  local bin_dir="${ws}/bin"
+  mkdir -p "$bin_dir"
+  local asdf_data="${ws}/asdf"
+  mkdir -p "$asdf_data/shims"
+  local cli_log="${ws}/cli.log"
+  local asdf_log="${ws}/asdf.log"
+  : > "$cli_log"; : > "$asdf_log"
+  mkdir -p "${ws}/work"
+  local path_bin="${bin_dir}/repo-toolkit-compose-sandbox"
+  make_fake_bin "$path_bin" "success"
+  make_fake_asdf "$bin_dir" "$asdf_data"
+  export PATH="${bin_dir}:/usr/bin:/bin"
+  export ASDF_DATA_DIR="$asdf_data"
+  export FAKE_ASDF_LOG="$asdf_log"
+  export FAKE_CLI_LOG="$cli_log"
+  # Ensure no workspace bin exists
+  rm -rf "${ws}/node_modules"
+  local fake_action="${ws}/fake-action"
+  mkdir -p "$fake_action"
+
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.17.0" "COMPOSE_SANDBOX_ACTION_PATH=$fake_action"
+
+  local code
+  code="$(cat "$ws/exit_code")"
+  assert_eq "$code" "0" "PATH: exit"
+  assert_contains "$cli_log" "--config" "PATH: cli invoked"
+  rm -rf "$ws"
+  echo "✓ PATH bin"
+}
+
+# -------------------------------------------------------------------
+# Test 4: asdf pinned install
+# -------------------------------------------------------------------
+test_asdf() {
+  local ws
+  ws="$(mktemp -d -p "$workspace_root")"
+  local bin_dir="${ws}/bin"
+  mkdir -p "$bin_dir"
+  local asdf_data="${ws}/asdf"
+  mkdir -p "$asdf_data/shims"
+  local cli_log="${ws}/cli.log"
+  local asdf_log="${ws}/asdf.log"
+  : > "$cli_log"; : > "$asdf_log"
+  mkdir -p "${ws}/work"
+  make_fake_asdf "$bin_dir" "$asdf_data"
+  # Also need jq/node wrappers that delegate – already handled in make_fake_asdf
+  export PATH="${bin_dir}:/usr/bin:/bin"
+  export ASDF_DATA_DIR="$asdf_data"
+  export FAKE_ASDF_LOG="$asdf_log"
+  export FAKE_CLI_LOG="$cli_log"
+  # Ensure no other bins
+  rm -rf "${ws}/node_modules"
+  # Ensure PATH bin not present – fake asdf will not have command -v match initially
+  local fake_action="${ws}/fake-action"
+  mkdir -p "$fake_action"
+
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.17.0" "COMPOSE_SANDBOX_ACTION_PATH=$fake_action"
+
+  local code
+  code="$(cat "$ws/exit_code")"
+  assert_eq "$code" "0" "asdf: exit"
+  assert_contains "$asdf_log" "install 0.17.0" "asdf: installed exact version"
+  assert_contains "$cli_log" "--config" "asdf: cli invoked"
+  rm -rf "$ws"
+  echo "✓ asdf pinned"
+}
+
+# -------------------------------------------------------------------
+# Test 5: injection resistance – malicious config/cwd values passed literally
+# -------------------------------------------------------------------
+test_injection() {
+  local ws
+  ws="$(mktemp -d -p "$workspace_root")"
+  local bin_dir="${ws}/bin"
+  mkdir -p "$bin_dir"
+  local asdf_data="${ws}/asdf"
+  mkdir -p "$asdf_data/shims"
+  local cli_log="${ws}/cli.log"
+  local asdf_log="${ws}/asdf.log"
+  : > "$cli_log"; : > "$asdf_log"
+  # cwd with spaces and metachars
+  local cwd_with_space="${ws}/work space; evil"
+  mkdir -p "$cwd_with_space"
+  local explicit_bin="${ws}/my-bin/repo-toolkit-compose-sandbox"
+  mkdir -p "$(dirname "$explicit_bin")"
+  make_fake_bin "$explicit_bin" "success"
+  make_fake_asdf "$bin_dir" "$asdf_data"
+  export PATH="${bin_dir}:/usr/bin:/bin"
+  export ASDF_DATA_DIR="$asdf_data"
+  export FAKE_ASDF_LOG="$asdf_log"
+  export FAKE_CLI_LOG="$cli_log"
+
+  local marker="${ws}/marker.should-not-exist"
+  rm -f "$marker"
+  local malicious_config='sandbox/evil; touch '"$marker"' --config.mjs'
+  # The config file path itself with spaces/semicolons – we create cwd and then pass this as config input.
+  # Our run.sh should pass it as single arg without shell evaluation, so marker not created.
+
+  run_sandbox "$ws" "$cwd_with_space" "$malicious_config" "COMPOSE_SANDBOX_INPUT_BIN=$explicit_bin" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.17.0"
+
+  assert_file_not_exists "$marker" "injection: marker should not be created"
+  # Check that cli received the malicious string as single ARG
+  assert_contains "$cli_log" "$malicious_config" "injection: cli got literal config"
+  # Also ensure cwd was passed literally: check ARG for cwd
+  assert_contains "$cli_log" "$cwd_with_space" "injection: cwd literal"
+  rm -rf "$ws"
+  echo "✓ injection resistance"
+}
+
+# -------------------------------------------------------------------
+# Test 6: version validation rejects latest and invalid
+# -------------------------------------------------------------------
+test_version_reject() {
+  local ws
+  ws="$(mktemp -d -p "$workspace_root")"
+  mkdir -p "${ws}/work"
+  local bin_dir="${ws}/bin"
+  mkdir -p "$bin_dir"
+  local asdf_data="${ws}/asdf"
+  mkdir -p "$asdf_data/shims"
+  make_fake_asdf "$bin_dir" "$asdf_data"
+  export PATH="${bin_dir}:/usr/bin:/bin"
+  export ASDF_DATA_DIR="$asdf_data"
+  export FAKE_ASDF_LOG="${ws}/asdf.log"
+  export FAKE_CLI_LOG="${ws}/cli.log"
+
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=latest"
+  local code
+  code="$(cat "$ws/exit_code")"
+  if [[ "$code" == "0" ]]; then echo "FAIL version reject latest should fail" >&2; exit 1; fi
+  # also check error message mentions semver
+  assert_contains "${ws}/err.log" "exact semver" "version reject latest msg"
+
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=^0.17.0"
+  code="$(cat "$ws/exit_code")"
+  if [[ "$code" == "0" ]]; then echo "FAIL version reject ^ should fail" >&2; exit 1; fi
+
+  # empty version should fallback to default 0.17.0 and succeed when bin is available
+  local good_bin="${ws}/good-bin/repo-toolkit-compose-sandbox"
+  mkdir -p "$(dirname "$good_bin")"
+  make_fake_bin "$good_bin" "success"
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$good_bin" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION="
+  code="$(cat "$ws/exit_code")"
+  if [[ "$code" != "0" ]]; then echo "FAIL empty version should fallback to default and succeed, got $code" >&2; cat "${ws}/err.log" >&2; exit 1; fi
+
+  rm -rf "$ws"
+  echo "✓ version validation"
+}
+
+# -------------------------------------------------------------------
+# Test 7: toolkit nonzero preserved and manifest available
+# -------------------------------------------------------------------
+test_toolkit_failure() {
+  local ws
+  ws="$(mktemp -d -p "$workspace_root")"
+  local bin_dir="${ws}/bin"
+  mkdir -p "$bin_dir"
+  local asdf_data="${ws}/asdf"
+  mkdir -p "$asdf_data/shims"
+  local cli_log="${ws}/cli.log"
+  local asdf_log="${ws}/asdf.log"
+  : > "$cli_log"; : > "$asdf_log"
+  mkdir -p "${ws}/work"
+  local explicit_bin="${ws}/my-bin/repo-toolkit-compose-sandbox"
+  mkdir -p "$(dirname "$explicit_bin")"
+  make_fake_bin "$explicit_bin" "fail"
+  make_fake_asdf "$bin_dir" "$asdf_data"
+  export PATH="${bin_dir}:/usr/bin:/bin"
+  export ASDF_DATA_DIR="$asdf_data"
+  export FAKE_ASDF_LOG="$asdf_log"
+  export FAKE_CLI_LOG="$cli_log"
+
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$explicit_bin" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.17.0"
+
+  local code
+  code="$(cat "$ws/exit_code")"
+  assert_eq "$code" "2" "toolkit failure: exit preserved"
+  local outcome
+  outcome="$(get_output "$ws" "outcome")"
+  assert_eq "$outcome" "failure" "toolkit failure: outcome"
+  local phase
+  phase="$(get_output "$ws" "failed-phase")"
+  assert_eq "$phase" "test" "toolkit failure: phase"
+  local manifest
+  manifest="$(get_output "$ws" "result-manifest")"
+  assert_file_exists "$manifest" "toolkit failure: manifest exists"
+  local evidence
+  evidence="$(get_output "$ws" "evidence-directory")"
+  assert_file_exists "$evidence/result.json" "toolkit failure: evidence dir has manifest"
+  rm -rf "$ws"
+  echo "✓ toolkit failure preserved"
+}
+
+# -------------------------------------------------------------------
+# Test 8: artifact policy – failure, always, never
+# -------------------------------------------------------------------
+test_policy() {
+  local ws
+  ws="$(mktemp -d -p "$workspace_root")"
+  local bin_dir="${ws}/bin"
+  mkdir -p "$bin_dir"
+  local asdf_data="${ws}/asdf"
+  mkdir -p "$asdf_data/shims"
+  local cli_log="${ws}/cli.log"
+  : > "$cli_log"
+  mkdir -p "${ws}/work"
+  local success_bin="${ws}/my-bin-success/repo-toolkit-compose-sandbox"
+  mkdir -p "$(dirname "$success_bin")"
+  make_fake_bin "$success_bin" "success"
+  local fail_bin="${ws}/my-bin-fail/repo-toolkit-compose-sandbox"
+  mkdir -p "$(dirname "$fail_bin")"
+  make_fake_bin "$fail_bin" "fail"
+  make_fake_asdf "$bin_dir" "$asdf_data"
+  export PATH="${bin_dir}:/usr/bin:/bin"
+  export ASDF_DATA_DIR="$asdf_data"
+  export FAKE_ASDF_LOG="${ws}/asdf.log"
+  export FAKE_CLI_LOG="$cli_log"
+
+  # success + failure policy => no artifact
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$success_bin" "COMPOSE_SANDBOX_INPUT_ARTIFACT_POLICY=failure" "COMPOSE_SANDBOX_INPUT_ARTIFACT_NAME=my-artifact"
+  local art
+  art="$(get_output "$ws" "artifact-name")"
+  assert_eq "$art" "" "policy failure+success: no artifact"
+
+  # failure + failure policy => artifact
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$fail_bin" "COMPOSE_SANDBOX_INPUT_ARTIFACT_POLICY=failure" "COMPOSE_SANDBOX_INPUT_ARTIFACT_NAME=my-artifact"
+  art="$(get_output "$ws" "artifact-name")"
+  assert_eq "$art" "my-artifact" "policy failure+failure: artifact"
+
+  # success + always => artifact
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$success_bin" "COMPOSE_SANDBOX_INPUT_ARTIFACT_POLICY=always" "COMPOSE_SANDBOX_INPUT_ARTIFACT_NAME=my-artifact"
+  art="$(get_output "$ws" "artifact-name")"
+  assert_eq "$art" "my-artifact" "policy always+success"
+
+  # failure + always => artifact
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$fail_bin" "COMPOSE_SANDBOX_INPUT_ARTIFACT_POLICY=always" "COMPOSE_SANDBOX_INPUT_ARTIFACT_NAME=my-artifact"
+  art="$(get_output "$ws" "artifact-name")"
+  assert_eq "$art" "my-artifact" "policy always+failure"
+
+  # any + never => no artifact
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$success_bin" "COMPOSE_SANDBOX_INPUT_ARTIFACT_POLICY=never" "COMPOSE_SANDBOX_INPUT_ARTIFACT_NAME=my-artifact"
+  art="$(get_output "$ws" "artifact-name")"
+  assert_eq "$art" "" "policy never"
+
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$fail_bin" "COMPOSE_SANDBOX_INPUT_ARTIFACT_POLICY=never" "COMPOSE_SANDBOX_INPUT_ARTIFACT_NAME=my-artifact"
+  art="$(get_output "$ws" "artifact-name")"
+  assert_eq "$art" "" "policy never failure"
+
+  rm -rf "$ws"
+  echo "✓ artifact policy"
+}
+
+# -------------------------------------------------------------------
+# Test 9: malformed and missing manifest
+# -------------------------------------------------------------------
+test_malformed() {
+  local ws
+  ws="$(mktemp -d -p "$workspace_root")"
+  local bin_dir="${ws}/bin"
+  mkdir -p "$bin_dir"
+  local asdf_data="${ws}/asdf"
+  mkdir -p "$asdf_data/shims"
+  local cli_log="${ws}/cli.log"
+  : > "$cli_log"
+  mkdir -p "${ws}/work"
+  # fake bin that writes malformed JSON
+  local mal_bin="${ws}/mal-bin/repo-toolkit-compose-sandbox"
+  mkdir -p "$(dirname "$mal_bin")"
+  cat > "$mal_bin" <<'MB'
+#!/usr/bin/env bash
+set -euo pipefail
+log="${FAKE_CLI_LOG:-/tmp/cli.log}"
+echo "$*" >> "$log"
+cwd=""
+args=("$@")
+for i in "${!args[@]}"; do if [[ "${args[i]}" == "--cwd" ]]; then cwd="${args[i+1]:-}"; fi; done
+mkdir -p "$cwd/.compose-sandbox-logs"
+echo "not json {{{" > "$cwd/.compose-sandbox-logs/result.json"
+exit 2
+MB
+  chmod 755 "$mal_bin"
+  make_fake_asdf "$bin_dir" "$asdf_data"
+  export PATH="${bin_dir}:/usr/bin:/bin"
+  export ASDF_DATA_DIR="$asdf_data"
+  export FAKE_ASDF_LOG="${ws}/asdf.log"
+  export FAKE_CLI_LOG="$cli_log"
+
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$mal_bin" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.17.0" "COMPOSE_SANDBOX_INPUT_ARTIFACT_POLICY=failure"
+  local code
+  code="$(cat "$ws/exit_code")"
+  assert_eq "$code" "2" "malformed: exit preserved"
+  # Should not crash; outcome should be failure
+  local outcome
+  outcome="$(get_output "$ws" "outcome")"
+  # Our run.sh will try to parse malformed and fallback to engine status => failure
+  if [[ "$outcome" != "failure" ]]; then echo "FAIL malformed outcome got $outcome" >&2; exit 1; fi
+  # Ensure no eval – marker file not created via content
+  if grep -Fq -- "not json" "${ws}/err.log" 2>/dev/null; then
+    # It's okay to log warning but not expose raw?
+    :
+  fi
+  # Now test summarize.sh handles malformed without exposing
+  local manifest
+  manifest="$(get_output "$ws" "result-manifest")"
+  # Run summarize
+  local summary="${ws}/summary_out"
+  GITHUB_STEP_SUMMARY="$summary" \
+  COMPOSE_SANDBOX_RESULT_MANIFEST="$manifest" \
+  COMPOSE_SANDBOX_EVIDENCE_DIRECTORY="$(get_output "$ws" "evidence-directory")" \
+  COMPOSE_SANDBOX_OUTCOME="$outcome" \
+  bash "${repo_root}/compose-sandbox/summarize.sh"
+  assert_contains "$summary" "malformed manifest" "malformed summary"
+  assert_not_contains "$summary" "not json" "malformed summary should not leak raw? Actually we mention invalid JSON but not raw content with secrets – here raw is not secret so okay"
+
+  # Missing manifest: bin that succeeds but doesn't write manifest
+  local nomani_bin="${ws}/nomanifest/repo-toolkit-compose-sandbox"
+  mkdir -p "$(dirname "$nomani_bin")"
+  cat > "$nomani_bin" <<'NM'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >> "${FAKE_CLI_LOG:?}"
+exit 0
+NM
+  chmod 755 "$nomani_bin"
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$nomani_bin" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.17.0"
+  code="$(cat "$ws/exit_code")"
+  assert_eq "$code" "0" "missing manifest success exit"
+  outcome="$(get_output "$ws" "outcome")"
+  assert_eq "$outcome" "success" "missing manifest success outcome"
+  # failure case with no manifest
+  cat > "$nomani_bin" <<'NM2'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "$*" >> "${FAKE_CLI_LOG:?}"
+exit 3
+NM2
+  chmod 755 "$nomani_bin"
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$nomani_bin" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.17.0"
+  code="$(cat "$ws/exit_code")"
+  assert_eq "$code" "3" "missing manifest failure exit"
+  outcome="$(get_output "$ws" "outcome")"
+  assert_eq "$outcome" "failure" "missing manifest failure outcome"
+
+  rm -rf "$ws"
+  echo "✓ malformed/missing manifest"
+}
+
+# -------------------------------------------------------------------
+# Test 10: secret redaction – manifest contains secret, summary/output must not leak?
+# -------------------------------------------------------------------
+test_secret() {
+  local ws
+  ws="$(mktemp -d -p "$workspace_root")"
+  local bin_dir="${ws}/bin"
+  mkdir -p "$bin_dir"
+  local asdf_data="${ws}/asdf"
+  mkdir -p "$asdf_data/shims"
+  local cli_log="${ws}/cli.log"
+  : > "$cli_log"
+  mkdir -p "${ws}/work"
+  local secret="s3cr3t-token-123"
+  local secret_bin="${ws}/secret-bin/repo-toolkit-compose-sandbox"
+  mkdir -p "$(dirname "$secret_bin")"
+  cat > "$secret_bin" <<EOS
+#!/usr/bin/env bash
+set -euo pipefail
+echo "\$*" >> "${FAKE_CLI_LOG:?}"
+cwd=""
+args=("\$@")
+for i in "\${!args[@]}"; do if [[ "\${args[i]}" == "--cwd" ]]; then cwd="\${args[i+1]:-}"; fi; done
+mkdir -p "\$cwd/.compose-sandbox-logs"
+# Manifest contains secret in error message (simulate redacted engine should have stripped, but we test our handling)
+cat > "\$cwd/.compose-sandbox-logs/result.json" <<JSON
+{"phase":"test","outcome":"failure","errors":{"primary":"test failed with token $secret"},"timings":{},"evidenceFiles":["result.json"]}
+JSON
+exit 2
+EOS
+  chmod 755 "$secret_bin"
+  make_fake_asdf "$bin_dir" "$asdf_data"
+  export PATH="${bin_dir}:/usr/bin:/bin"
+  export ASDF_DATA_DIR="$asdf_data"
+  export FAKE_ASDF_LOG="${ws}/asdf.log"
+  export FAKE_CLI_LOG="$cli_log"
+  # Also set secret in env to simulate config env leakage attempt – run.sh should not print it
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$secret_bin" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.17.0"
+
+  # Check that GITHUB_OUTPUT does not contain secret (our sanitize should have stripped? Actually manifest still has secret, but we sanitize phase/outcome only – evidenceFiles not secret. The raw manifest has secret, but our output only includes outcome/phase, not raw errors. So output should not contain secret.)
+  local out_copy="${ws}/gh_out_copy"
+  assert_not_contains "$out_copy" "$secret" "secret not in output"
+
+  # Check err log does not contain secret (run.sh redacts by not printing config)
+  assert_not_contains "${ws}/err.log" "$secret" "secret not in stderr"
+  # Check summary does not contain secret
+  local manifest
+  manifest="$(get_output "$ws" "result-manifest")"
+  local summary="${ws}/summary_secret"
+  GITHUB_STEP_SUMMARY="$summary" COMPOSE_SANDBOX_RESULT_MANIFEST="$manifest" COMPOSE_SANDBOX_EVIDENCE_DIRECTORY="$(get_output "$ws" "evidence-directory")" COMPOSE_SANDBOX_OUTCOME="$(get_output "$ws" "outcome")" bash "${repo_root}/compose-sandbox/summarize.sh"
+  assert_not_contains "$summary" "$secret" "secret not in summary"
+
+  rm -rf "$ws"
+  echo "✓ secret redaction"
+}
+
+# -------------------------------------------------------------------
+# Test 11: artifact name validation
+# -------------------------------------------------------------------
+test_artifact_name_invalid() {
+  local ws
+  ws="$(mktemp -d -p "$workspace_root")"
+  mkdir -p "${ws}/work"
+  local bin_dir="${ws}/bin"
+  mkdir -p "$bin_dir"
+  local asdf_data="${ws}/asdf"
+  mkdir -p "$asdf_data/shims"
+  make_fake_asdf "$bin_dir" "$asdf_data"
+  export PATH="${bin_dir}:/usr/bin:/bin"
+  export ASDF_DATA_DIR="$asdf_data"
+  export FAKE_ASDF_LOG="${ws}/asdf.log"
+  export FAKE_CLI_LOG="${ws}/cli.log"
+  local good_bin="${ws}/good/repo-toolkit-compose-sandbox"
+  mkdir -p "$(dirname "$good_bin")"
+  make_fake_bin "$good_bin" "success"
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$good_bin" "COMPOSE_SANDBOX_INPUT_ARTIFACT_NAME=bad/name"
+  local code
+  code="$(cat "$ws/exit_code")"
+  if [[ "$code" == "0" ]]; then echo "FAIL artifact slash should reject" >&2; exit 1; fi
+  assert_contains "${ws}/err.log" "artifact-name" "artifact name slash error"
+
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$good_bin" "COMPOSE_SANDBOX_INPUT_ARTIFACT_NAME=bad name with spaces"
+  code="$(cat "$ws/exit_code")"
+  if [[ "$code" == "0" ]]; then echo "FAIL artifact spaces should reject" >&2; exit 1; fi
+
+  rm -rf "$ws"
+  echo "✓ artifact name validation"
+}
+
+# -------------------------------------------------------------------
+# Test 12: success outputs completeness
+# -------------------------------------------------------------------
+test_success_outputs() {
+  local ws
+  ws="$(mktemp -d -p "$workspace_root")"
+  local bin_dir="${ws}/bin"
+  mkdir -p "$bin_dir"
+  local asdf_data="${ws}/asdf"
+  mkdir -p "$asdf_data/shims"
+  local cli_log="${ws}/cli.log"
+  : > "$cli_log"
+  mkdir -p "${ws}/work"
+  local bin="${ws}/bin2/repo-toolkit-compose-sandbox"
+  mkdir -p "$(dirname "$bin")"
+  make_fake_bin "$bin" "success"
+  make_fake_asdf "$bin_dir" "$asdf_data"
+  export PATH="${bin_dir}:/usr/bin:/bin"
+  export ASDF_DATA_DIR="$asdf_data"
+  export FAKE_ASDF_LOG="${ws}/asdf.log"
+  export FAKE_CLI_LOG="$cli_log"
+
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$bin" "COMPOSE_SANDBOX_INPUT_ARTIFACT_POLICY=always" "COMPOSE_SANDBOX_INPUT_ARTIFACT_NAME=my-art"
+  local outcome
+  outcome="$(get_output "$ws" "outcome")"
+  assert_eq "$outcome" "success" "success outputs outcome"
+  local failed
+  failed="$(get_output "$ws" "failed-phase")"
+  assert_eq "$failed" "" "success failed-phase empty"
+  local ev
+  ev="$(get_output "$ws" "evidence-directory")"
+  assert_file_exists "$ev" "success evidence dir exists"
+  local mani
+  mani="$(get_output "$ws" "result-manifest")"
+  assert_file_exists "$mani" "success manifest exists"
+  local art
+  art="$(get_output "$ws" "artifact-name")"
+  assert_eq "$art" "my-art" "success artifact with always"
+
+  # summary
+  local summary="${ws}/summary_ok"
+  GITHUB_STEP_SUMMARY="$summary" COMPOSE_SANDBOX_RESULT_MANIFEST="$mani" COMPOSE_SANDBOX_EVIDENCE_DIRECTORY="$ev" COMPOSE_SANDBOX_OUTCOME="$outcome" bash "${repo_root}/compose-sandbox/summarize.sh"
+  assert_contains "$summary" "outcome: \`success\`" "success summary outcome"
+  assert_contains "$summary" "evidence" "success summary evidence"
+
+  rm -rf "$ws"
+  echo "✓ success outputs"
+}
+
+# Run all
+test_explicit
+test_workspace
+test_path
+test_asdf
+test_injection
+test_version_reject
+test_toolkit_failure
+test_policy
+test_malformed
+test_secret
+test_artifact_name_invalid
+test_success_outputs
+
+printf 'compose-sandbox shell tests passed\n'


### PR DESCRIPTION
## Summary

Adds a new `compose-sandbox` composite GitHub Action for running repository-defined Docker Compose sandboxes through the repo-toolkit lifecycle engine.

## What changed

- Introduced the `compose-sandbox` action with:
  - validated inputs for config, cwd, binary resolution, toolkit version, and artifact behavior
  - lifecycle execution via `run.sh`
  - summary generation via `summarize.sh`
  - optional evidence artifact upload
- Added comprehensive action documentation in `compose-sandbox/README.md`
- Added a GitHub Actions workflow to exercise success and failure paths for the action
- Added fixture sandbox files and a shell test for local verification
- Updated repository docs and package metadata to include the new action and toolkit dependency
- Refreshed pnpm workspace lock/config entries for the new `@repo-toolkit/compose-sandbox` package and updated versions

## Notes

- The action is designed to be a thin wrapper around the repo-toolkit compose sandbox engine.
- Tests cover both successful and failing sandbox runs, along with artifact/output assertions and cleanup checks.
- Documentation includes usage examples, input/output references, security notes, and migration guidance for consumers.

## Verification

- Added shell test coverage under `tests/test-compose-sandbox.sh`
- Added workflow coverage in `.github/workflows/test-compose-sandbox.yml`
- Included fixture configs under `tests/fixtures/compose-sandbox/` for deterministic local and CI testing