### PR TITLE
Update compose sandbox artifact action digest

### DIFF
--- a/compose-sandbox/action.yml
+++ b/compose-sandbox/action.yml
@@ -79,7 +79,7 @@ runs:
     run: bash "${{ github.action_path }}/summarize.sh"
   - name: Upload sandbox evidence
     if: ${{ always() && steps.sandbox.outputs.artifact-name != '' && steps.sandbox.outputs.evidence-directory != '' }}
-    uses: actions/upload-artifact@65462800fd760344a2a7ede2ed4f50aede65e8c
+    uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808
     with:
       name: ${{ steps.sandbox.outputs.artifact-name }}
       path: ${{ steps.sandbox.outputs.evidence-directory }}


### PR DESCRIPTION
## Summary
- update the `actions/upload-artifact` digest used by `compose-sandbox/action.yml`

## Details
- keeps the sandbox evidence upload step pinned to the newer artifact action digest
- no functional workflow logic changed beyond the dependency reference update

## Files changed
- `compose-sandbox/action.yml`