### PR TITLE
Bump compose sandbox to repo-toolkit 0.18.0

### DIFF
--- a/.github/workflows/test-compose-sandbox.yml
+++ b/.github/workflows/test-compose-sandbox.yml
@@ -42,7 +42,7 @@ jobs:
       with:
         config: success.mjs
         cwd: tests/fixtures/compose-sandbox
-        repo-toolkit-version: 0.17.0
+        repo-toolkit-version: 0.18.0
         artifact-name: compose-sandbox-success-logs
         artifact-policy: always
 
@@ -126,7 +126,7 @@ jobs:
       with:
         config: failure.mjs
         cwd: tests/fixtures/compose-sandbox
-        repo-toolkit-version: 0.17.0
+        repo-toolkit-version: 0.18.0
         artifact-name: compose-sandbox-failure-logs
         artifact-policy: failure
 

--- a/compose-sandbox/README.md
+++ b/compose-sandbox/README.md
@@ -25,7 +25,7 @@ The caller must provide before invoking the action:
 
 ## Usage
 
-All examples pin both the action and the toolkit to immutable refs. Replace `<commit-sha>` with the exact commit SHA from the release you intend to run (check the release notes for the tested `repo-toolkit-version`, current default `0.17.0`).
+All examples pin both the action and the toolkit to immutable refs. Replace `<commit-sha>` with the exact commit SHA from the release you intend to run (check the release notes for the tested `repo-toolkit-version`, current default `0.18.0`).
 
 ### Minimal
 
@@ -88,7 +88,7 @@ Workflow:
   with:
     config: sandbox/database-sandbox.mjs
     cwd: ${{ github.workspace }}
-    repo-toolkit-version: 0.17.0
+    repo-toolkit-version: 0.18.0
     artifact-name: integration-service-logs-${{ matrix.startup-attempt }}
     artifact-policy: failure
 ```
@@ -135,7 +135,7 @@ Workflow:
 | `config` | Yes | — | Path to the toolkit config file (JSON, `.mjs`, or `.cjs`). Resolved relative to `cwd`. |
 | `cwd` | No | `${{ github.workspace }}` | Working directory the engine resolves relative paths against. Must be inside the workspace when provided. |
 | `compose-sandbox-bin` | No | `` | Explicit path to the `repo-toolkit-compose-sandbox` executable. When set, bypasses workspace/`PATH`/`asdf` resolution. Useful for local development and fixture tests. |
-| `repo-toolkit-version` | No | `0.17.0` | Exact `repo-toolkit` version to install via `asdf` when the binary is not found. Must be an exact semver; `latest` is rejected. Pinned to the version tested with this action release. |
+| `repo-toolkit-version` | No | `0.18.0` | Exact `repo-toolkit` version to install via `asdf` when the binary is not found. Must be an exact semver; `latest` is rejected. Pinned to the version tested with this action release. |
 | `repo-toolkit-plugin-url` | No | `https://github.com/egose/repo-toolkit.git` | Git URL for the `repo-toolkit` `asdf` plugin. |
 | `artifact-name` | No | `compose-sandbox-logs` | Name of the GitHub artifact uploaded from the evidence directory. Ignored when `artifact-policy` is `never` or when no evidence is produced. |
 | `artifact-policy` | No | `failure` | When to upload evidence. One of `failure` (only on sandbox failure), `always`, or `never`. |
@@ -145,7 +145,7 @@ No input accepts a multiline shell command. Test and readiness commands belong i
 
 ### Pinned toolkit version
 
-`repo-toolkit-version` defaults to the exact version tested with this action release (`0.17.0`), not `latest`. Every network installation path validates that the requested version is an exact semver and installs that version only. Third-party GitHub Actions used by the action itself are pinned to full commit SHAs. Consumers should keep `uses: egose/actions/compose-sandbox@<sha>` pinned to a commit SHA as well.
+`repo-toolkit-version` defaults to the exact version tested with this action release (`0.18.0`), not `latest`. Every network installation path validates that the requested version is an exact semver and installs that version only. Third-party GitHub Actions used by the action itself are pinned to full commit SHAs. Consumers should keep `uses: egose/actions/compose-sandbox@<sha>` pinned to a commit SHA as well.
 
 ## Outputs
 

--- a/compose-sandbox/action.yml
+++ b/compose-sandbox/action.yml
@@ -13,9 +13,9 @@ inputs:
     required: false
     default: ''
   repo-toolkit-version:
-    description: Exact repo-toolkit version to install via asdf when the binary is not found. Must be an exact semver (e.g. 0.17.0), not latest.
+    description: Exact repo-toolkit version to install via asdf when the binary is not found. Must be an exact semver (e.g. 0.18.0), not latest.
     required: false
-    default: 0.17.0
+    default: 0.18.0
   repo-toolkit-plugin-url:
     description: Git URL for the repo-toolkit asdf plugin
     required: false

--- a/compose-sandbox/run.sh
+++ b/compose-sandbox/run.sh
@@ -23,7 +23,7 @@ validate_semver() {
   fi
   # semver: X.Y.Z with optional prerelease/build
   if ! [[ "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
-    echo "❌ $label must be an exact semver (e.g. 0.17.0), got: $v" >&2
+    echo "❌ $label must be an exact semver (e.g. 0.18.0), got: $v" >&2
     return 1
   fi
   if [[ "$v" == *".."* || "$v" == *"//"* ]]; then
@@ -145,7 +145,7 @@ install_repo_toolkit_via_asdf() {
   fi
   ensure_asdf_available || return 1
 
-  local toolkit_version="${COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION:-0.17.0}"
+  local toolkit_version="${COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION:-0.18.0}"
   local toolkit_plugin_url="${COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_PLUGIN_URL:-https://github.com/egose/repo-toolkit.git}"
   validate_semver "$toolkit_version" "repo-toolkit-version" || return 1
   COMPOSE_SANDBOX_RESOLVED_BIN=""
@@ -248,7 +248,7 @@ resolve_binary() {
     fi
   fi
 
-  echo >&2 "❌ repo-toolkit-compose-sandbox not found. Install it via pnpm add -D @repo-toolkit/compose-sandbox@${COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION:-0.17.0} or ensure asdf is available."
+  echo >&2 "❌ repo-toolkit-compose-sandbox not found. Install it via pnpm add -D @repo-toolkit/compose-sandbox@${COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION:-0.18.0} or ensure asdf is available."
   return 1
 }
 
@@ -353,7 +353,7 @@ main() {
   local retention="${COMPOSE_SANDBOX_INPUT_ARTIFACT_RETENTION_DAYS:-}"
   validate_retention "$retention" || exit 1
 
-  local version_input="${COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION:-0.17.0}"
+  local version_input="${COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION:-0.18.0}"
   validate_semver "$version_input" "repo-toolkit-version" || exit 1
 
   local cwd_input="${COMPOSE_SANDBOX_INPUT_CWD:-${GITHUB_WORKSPACE:-$(pwd)}}"
@@ -395,6 +395,22 @@ main() {
   # Resolve binary BEFORE cd to cwd so workspace lookups use runner workspace
   local bin
   bin="$(resolve_binary)" || exit 1
+  echo "✅ using binary: $bin" >&2
+  echo "📋 cwd: $cwd_abs" >&2
+  echo "📋 config: $config_abs" >&2
+
+  if command -v docker >/dev/null 2>&1; then
+    echo "🐳 checking docker compose version..." >&2
+    local compose_ver_raw=""
+    compose_ver_raw="$(docker compose version 2>&1 | head -n 1 | tr -d '\r' | sed -E 's/\x1B\[[0-9;]*[A-Za-z]//g' 2>/dev/null | cut -c1-500 || true)"
+    if [[ -n "$compose_ver_raw" ]]; then
+      echo "🐳 $compose_ver_raw" >&2
+    else
+      echo "⚠️ docker compose version returned empty" >&2
+    fi
+  else
+    echo "⚠️ docker executable not found; engine preflight will report failure" >&2
+  fi
 
   # Now cd to cwd for engine execution (engine expects cwd)
   cd "$cwd_abs"
@@ -524,6 +540,51 @@ main() {
     fi
   fi
   artifact_output="$(sanitize_for_output "$artifact_output")"
+
+  # Console summary for visibility in every step (engine also logs per-phase)
+  {
+    local summary_icon="✅"
+    if [[ "$sanitized_outcome" == "failure" ]]; then summary_icon="❌"; fi
+    if [[ -n "${GITHUB_ACTIONS:-}" ]]; then echo "::group::Compose sandbox summary" >&2; fi
+    echo "${summary_icon} outcome=${sanitized_outcome} phase=${sanitized_phase:-none} engine_status=${engine_status}" >&2
+    if [[ -n "$sanitized_evidence_dir" ]]; then echo "📁 evidence-directory=${sanitized_evidence_dir}" >&2; fi
+    if [[ -n "$sanitized_manifest" ]]; then echo "📄 result-manifest=${sanitized_manifest}" >&2; fi
+    if [[ -n "$manifest_path" && -f "$manifest_path" ]]; then
+      local timings_line=""
+      if command -v python3 >/dev/null 2>&1; then
+        timings_line="$(python3 - "$manifest_path" <<'PY' 2>/dev/null || true
+import json,sys
+p=sys.argv[1]
+try:
+  d=json.load(open(p))
+  t=d.get('timings',{})
+  files=d.get('evidenceFiles',[])
+  phase=d.get('phase','')
+  outcome=d.get('outcome','')
+  err=d.get('errors',{}).get('primary','')
+  print(f"timings total={t.get('total',0)}ms validate={t.get('validate',0)}ms prepare={t.get('prepare',0)}ms preflight={t.get('preflight',0)}ms start={t.get('start',0)}ms readiness={t.get('readiness',0)}ms test={t.get('test',0)}ms evidence={t.get('evidence',0)}ms cleanup={t.get('cleanup',0)}ms | phase={phase} outcome={outcome} files={','.join(files)}")
+  if err:
+    print(f"primary error: {str(err)[:500]}")
+except: pass
+PY
+)"
+        if [[ -n "$timings_line" ]]; then
+          echo "⏱ $timings_line" | head -n 5 >&2
+        fi
+      elif command -v jq >/dev/null 2>&1; then
+        echo "⏱ $(jq -c '{phase,outcome,timings,evidenceFiles} // empty' "$manifest_path" 2>/dev/null | cut -c1-500)" >&2
+      fi
+      if [[ -n "$artifact_output" ]]; then
+        echo "📦 artifact=${artifact_output} policy=${policy}" >&2
+      else
+        echo "📦 artifact: none (policy=${policy} outcome=${sanitized_outcome})" >&2
+      fi
+    else
+      echo "⚠️ no manifest found at ${manifest_path:-<none>}" >&2
+      if [[ -n "$artifact_output" ]]; then echo "📦 artifact=${artifact_output} (no manifest)" >&2; fi
+    fi
+    if [[ -n "${GITHUB_ACTIONS:-}" ]]; then echo "::endgroup::" >&2; fi
+  } || true
 
   # Write outputs to GITHUB_OUTPUT
   if [[ -n "${GITHUB_OUTPUT:-}" ]]; then

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "@commitlint/config-conventional": "^21.2.2",
     "@commitlint/format": "^21.2.2",
     "@release-it/bumper": "^8.0.0",
-    "@repo-toolkit/changelog": "^0.17.0",
-    "@repo-toolkit/compose-sandbox": "^0.17.0",
-    "@repo-toolkit/confluence": "^0.17.0",
+    "@repo-toolkit/changelog": "^0.18.0",
+    "@repo-toolkit/compose-sandbox": "^0.18.0",
+    "@repo-toolkit/confluence": "^0.18.0",
     "release-it": "^21.0.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,14 +21,14 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0(release-it@21.0.2(@types/node@25.6.0))
       '@repo-toolkit/changelog':
-        specifier: ^0.17.0
-        version: 0.17.0
+        specifier: ^0.18.0
+        version: 0.18.0
       '@repo-toolkit/compose-sandbox':
-        specifier: ^0.17.0
-        version: 0.17.0
+        specifier: ^0.18.0
+        version: 0.18.0
       '@repo-toolkit/confluence':
-        specifier: ^0.17.0
-        version: 0.17.0
+        specifier: ^0.18.0
+        version: 0.18.0
       release-it:
         specifier: ^21.0.2
         version: 21.0.2(@types/node@25.6.0)
@@ -369,23 +369,23 @@ packages:
     peerDependencies:
       release-it: ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0
 
-  '@repo-toolkit/changelog@0.17.0':
-    resolution: {integrity: sha512-QyffVnvWngfGIdsVyBld0/12NdKl2MM56mmuNyD3VV1I8oYjFQIawKmF5LNZyaOJEdODhAdYspiv5qm5PmWNdQ==}
+  '@repo-toolkit/changelog@0.18.0':
+    resolution: {integrity: sha512-t6ik6GPd0tqBgBxBl088O3aGCHETbGYKjrn0fQuUxKIc1NroEKTdhyyjygdssAx7ueINvF4YOj4Zf/QHmuC21Q==}
     engines: {node: '>=20'}
     hasBin: true
 
-  '@repo-toolkit/compose-sandbox@0.17.0':
-    resolution: {integrity: sha512-JGdyxnFTMNtH5sEuQmaZVaHRHydUEHC99n/TC/5tkkmvyyYQ8E1rfa7OQaS23FGaGk2VugAMJuaFDCN68+VWdA==}
+  '@repo-toolkit/compose-sandbox@0.18.0':
+    resolution: {integrity: sha512-M+JR/dbDYnbNxzHTamXbFwLvD1KNaAw1V8cw/qL1Ao1/NsXb22tDWltA8ieiQkE8dcC+r8jaRLzIoi8KH34irQ==}
     engines: {node: '>=20'}
     hasBin: true
 
-  '@repo-toolkit/confluence@0.17.0':
-    resolution: {integrity: sha512-abXPLweTLiVprmvw9zyCZJj82STRLd6ce5pyzUQkdvrYY1zubo2AwWtwmZBIojttasl2aN8WRUhpKec323HN4w==}
+  '@repo-toolkit/confluence@0.18.0':
+    resolution: {integrity: sha512-0k4qUGzMU74s4/QycIztNkhI68oXHkzjKC4wIO6o0qehEsZRS8ob/vDZlZ+zu0YBWQVmI9bSZrqHxe0BCsNhng==}
     engines: {node: '>=20'}
     hasBin: true
 
-  '@repo-toolkit/publish-package@0.17.0':
-    resolution: {integrity: sha512-GG3hHNQoq+GteBnujoXJyaGHRi21FZarAQKnajWb6T7WAOOeUmlmPbkJUaosgq6fYX/JeiGprRdLnjmW2s4ijg==}
+  '@repo-toolkit/publish-package@0.18.0':
+    resolution: {integrity: sha512-57it/u9E/kX5C9lp/WE2qfSXV/E0MKm8U5R4E2UkWtyhhOnOJqocqCUit2juhWuq6EJB9PTIUK9bjWd0sdQVng==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -1665,23 +1665,23 @@ snapshots:
       release-it: 21.0.2(@types/node@25.6.0)
       semver: 7.8.5
 
-  '@repo-toolkit/changelog@0.17.0':
+  '@repo-toolkit/changelog@0.18.0':
     dependencies:
-      '@repo-toolkit/publish-package': 0.17.0
+      '@repo-toolkit/publish-package': 0.18.0
       conventional-changelog: 7.2.1
       conventional-changelog-conventionalcommits: 9.3.1
     transitivePeerDependencies:
       - conventional-commits-filter
 
-  '@repo-toolkit/compose-sandbox@0.17.0':
+  '@repo-toolkit/compose-sandbox@0.18.0':
     dependencies:
-      '@repo-toolkit/publish-package': 0.17.0
+      '@repo-toolkit/publish-package': 0.18.0
 
-  '@repo-toolkit/confluence@0.17.0':
+  '@repo-toolkit/confluence@0.18.0':
     dependencies:
-      '@repo-toolkit/publish-package': 0.17.0
+      '@repo-toolkit/publish-package': 0.18.0
 
-  '@repo-toolkit/publish-package@0.17.0':
+  '@repo-toolkit/publish-package@0.18.0':
     dependencies:
       '@clack/prompts': 1.7.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,7 @@
 # gate (e.g. freshly-released @repo-toolkit/* packages that the action needs
 # immediately). Re-run `pnpm install` to refresh; do not format/sort by hand.
 minimumReleaseAgeExclude:
-- '@repo-toolkit/confluence@0.17.0'
-- '@repo-toolkit/publish-package@0.17.0'
-- '@repo-toolkit/changelog@0.17.0'
-- '@repo-toolkit/compose-sandbox@0.17.0'
+- '@repo-toolkit/confluence@0.17.0 || 0.18.0'
+- '@repo-toolkit/publish-package@0.17.0 || 0.18.0'
+- '@repo-toolkit/changelog@0.17.0 || 0.18.0'
+- '@repo-toolkit/compose-sandbox@0.17.0 || 0.18.0'

--- a/tests/fixtures/compose-sandbox/README.md
+++ b/tests/fixtures/compose-sandbox/README.md
@@ -8,7 +8,7 @@ Minimal real-Compose fixtures for GitHub-hosted integration tests.
 
 Both fixtures use distinct `projectName` values (`cs-test-success`, `cs-test-failure`) and bounded timeouts (60s startup/readiness, 30s test/cleanup) so parallel jobs do not leak containers/networks.
 
-The workflow `test-compose-sandbox.yml` exercises both success and forced-failure paths through `uses: ./compose-sandbox` with the exact published `@repo-toolkit/compose-sandbox@0.17.0`.
+The workflow `test-compose-sandbox.yml` exercises both success and forced-failure paths through `uses: ./compose-sandbox` with the exact published `@repo-toolkit/compose-sandbox@0.18.0`.
 
 Consumer-shaped references:
 

--- a/tests/test-compose-sandbox.sh
+++ b/tests/test-compose-sandbox.sh
@@ -123,8 +123,8 @@ case "${1:-}" in
   install)
     if [[ "${2:-}" == "repo-toolkit" ]]; then
       printf 'install %s\n' "${3:-}" >> "$log_file"
-      # only allow pinned version 0.17.0 for compose tests
-      if [[ "${3:-}" != "0.17.0" ]]; then
+      # only allow pinned version 0.18.0 for compose tests
+      if [[ "${3:-}" != "0.18.0" ]]; then
         printf 'unexpected version %s\n' "${3:-}" >&2
         exit 1
       fi
@@ -151,8 +151,8 @@ CLI
   reshim) printf 'reshim %s\n' "${2:-all}" >> "$log_file"; exit 0 ;;
   which)
     if [[ "${2:-}" == "repo-toolkit-compose-sandbox" ]]; then
-      if [[ -x "${asdf_data_dir}/installs/repo-toolkit/0.17.0/bin/repo-toolkit-compose-sandbox" ]]; then
-        printf '%s\n' "${asdf_data_dir}/installs/repo-toolkit/0.17.0/bin/repo-toolkit-compose-sandbox"
+      if [[ -x "${asdf_data_dir}/installs/repo-toolkit/0.18.0/bin/repo-toolkit-compose-sandbox" ]]; then
+        printf '%s\n' "${asdf_data_dir}/installs/repo-toolkit/0.18.0/bin/repo-toolkit-compose-sandbox"
         exit 0
       fi
       exit 1
@@ -260,7 +260,7 @@ test_explicit() {
   export FAKE_ASDF_LOG="$asdf_log"
   export FAKE_CLI_LOG="$cli_log"
 
-  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$explicit_bin" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.17.0"
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$explicit_bin" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.18.0"
 
   local code
   code="$(cat "$ws/exit_code")"
@@ -298,7 +298,7 @@ test_workspace() {
   export FAKE_ASDF_LOG="$asdf_log"
   export FAKE_CLI_LOG="$cli_log"
 
-  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.17.0"
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.18.0"
 
   local code
   code="$(cat "$ws/exit_code")"
@@ -335,7 +335,7 @@ test_path() {
   local fake_action="${ws}/fake-action"
   mkdir -p "$fake_action"
 
-  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.17.0" "COMPOSE_SANDBOX_ACTION_PATH=$fake_action"
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.18.0" "COMPOSE_SANDBOX_ACTION_PATH=$fake_action"
 
   local code
   code="$(cat "$ws/exit_code")"
@@ -371,12 +371,12 @@ test_asdf() {
   local fake_action="${ws}/fake-action"
   mkdir -p "$fake_action"
 
-  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.17.0" "COMPOSE_SANDBOX_ACTION_PATH=$fake_action"
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.18.0" "COMPOSE_SANDBOX_ACTION_PATH=$fake_action"
 
   local code
   code="$(cat "$ws/exit_code")"
   assert_eq "$code" "0" "asdf: exit"
-  assert_contains "$asdf_log" "install 0.17.0" "asdf: installed exact version"
+  assert_contains "$asdf_log" "install 0.18.0" "asdf: installed exact version"
   assert_contains "$cli_log" "--config" "asdf: cli invoked"
   rm -rf "$ws"
   echo "✓ asdf pinned"
@@ -413,7 +413,7 @@ test_injection() {
   # The config file path itself with spaces/semicolons – we create cwd and then pass this as config input.
   # Our run.sh should pass it as single arg without shell evaluation, so marker not created.
 
-  run_sandbox "$ws" "$cwd_with_space" "$malicious_config" "COMPOSE_SANDBOX_INPUT_BIN=$explicit_bin" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.17.0"
+  run_sandbox "$ws" "$cwd_with_space" "$malicious_config" "COMPOSE_SANDBOX_INPUT_BIN=$explicit_bin" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.18.0"
 
   assert_file_not_exists "$marker" "injection: marker should not be created"
   # Check that cli received the malicious string as single ARG
@@ -448,11 +448,11 @@ test_version_reject() {
   # also check error message mentions semver
   assert_contains "${ws}/err.log" "exact semver" "version reject latest msg"
 
-  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=^0.17.0"
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=^0.18.0"
   code="$(cat "$ws/exit_code")"
   if [[ "$code" == "0" ]]; then echo "FAIL version reject ^ should fail" >&2; exit 1; fi
 
-  # empty version should fallback to default 0.17.0 and succeed when bin is available
+  # empty version should fallback to default 0.18.0 and succeed when bin is available
   local good_bin="${ws}/good-bin/repo-toolkit-compose-sandbox"
   mkdir -p "$(dirname "$good_bin")"
   make_fake_bin "$good_bin" "success"
@@ -487,7 +487,7 @@ test_toolkit_failure() {
   export FAKE_ASDF_LOG="$asdf_log"
   export FAKE_CLI_LOG="$cli_log"
 
-  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$explicit_bin" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.17.0"
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$explicit_bin" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.18.0"
 
   local code
   code="$(cat "$ws/exit_code")"
@@ -602,7 +602,7 @@ MB
   export FAKE_ASDF_LOG="${ws}/asdf.log"
   export FAKE_CLI_LOG="$cli_log"
 
-  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$mal_bin" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.17.0" "COMPOSE_SANDBOX_INPUT_ARTIFACT_POLICY=failure"
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$mal_bin" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.18.0" "COMPOSE_SANDBOX_INPUT_ARTIFACT_POLICY=failure"
   local code
   code="$(cat "$ws/exit_code")"
   assert_eq "$code" "2" "malformed: exit preserved"
@@ -639,7 +639,7 @@ echo "$*" >> "${FAKE_CLI_LOG:?}"
 exit 0
 NM
   chmod 755 "$nomani_bin"
-  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$nomani_bin" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.17.0"
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$nomani_bin" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.18.0"
   code="$(cat "$ws/exit_code")"
   assert_eq "$code" "0" "missing manifest success exit"
   outcome="$(get_output "$ws" "outcome")"
@@ -652,7 +652,7 @@ echo "$*" >> "${FAKE_CLI_LOG:?}"
 exit 3
 NM2
   chmod 755 "$nomani_bin"
-  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$nomani_bin" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.17.0"
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$nomani_bin" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.18.0"
   code="$(cat "$ws/exit_code")"
   assert_eq "$code" "3" "missing manifest failure exit"
   outcome="$(get_output "$ws" "outcome")"
@@ -699,7 +699,7 @@ EOS
   export FAKE_ASDF_LOG="${ws}/asdf.log"
   export FAKE_CLI_LOG="$cli_log"
   # Also set secret in env to simulate config env leakage attempt – run.sh should not print it
-  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$secret_bin" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.17.0"
+  run_sandbox "$ws" "${ws}/work" "sandbox/config.mjs" "COMPOSE_SANDBOX_INPUT_BIN=$secret_bin" "COMPOSE_SANDBOX_INPUT_REPO_TOOLKIT_VERSION=0.18.0"
 
   # Check that GITHUB_OUTPUT does not contain secret (our sanitize should have stripped? Actually manifest still has secret, but we sanitize phase/outcome only – evidenceFiles not secret. The raw manifest has secret, but our output only includes outcome/phase, not raw errors. So output should not contain secret.)
   local out_copy="${ws}/gh_out_copy"


### PR DESCRIPTION
## Summary

This change updates the compose sandbox action, docs, tests, and workspace package pins to use `repo-toolkit` 0.18.0 as the default tested version.

## What changed

- Updated the compose sandbox action default input and validation examples to `0.18.0`.
- Updated runtime messages in `run.sh` to reference the new default version and added more verbose preflight/summary logging.
- Bumped workspace dependencies for the related `@repo-toolkit/*` packages to `^0.18.0` and refreshed the lockfile.
- Adjusted the pnpm minimum release age allowlist to include both `0.17.0` and `0.18.0` for the affected packages.
- Updated the compose sandbox README and fixture README to document the new default/tested version.
- Updated the compose sandbox integration test workflow and shell test expectations to use `0.18.0`.

## Notes

The change keeps the existing version pinning behavior intact; it only moves the default/tested version forward and aligns all docs and test fixtures with that release.