### PR TITLE
Add page title strategy input to Confluence action

### DIFF
--- a/confluence/README.md
+++ b/confluence/README.md
@@ -88,6 +88,7 @@ touching Confluence:
 | `space-key` | No | `` | Confluence space key (`ENG`, `~1234`, ...). Resolved to a `spaceId` via the API. |
 | `parent-page-id` | No | `` | Numeric Confluence page id under which docs will be published. Must be `^[0-9]+$`. |
 | `version-message` | No | `` | Suffix appended to every page/attachment PUT. |
+| `page-title-strategy` | No | `filename-stem` | Leaf page title strategy: `filename-stem` (default, filename without final `.md`), `filename` (with extension), `sentence-case-parent` (stem + immediate parent), `sentence-case-parents` (stem + all parents), `sentence-case-path` (stem + all parents + filename with extension). Folder pages keep raw directory names. See `@repo-toolkit/confluence` docs for naming contract, root-file behavior, and migration notes. |
 | `skip-unchanged` | No | `true` | Skip pages whose body is byte-identical to the current Confluence storage value. |
 | `dry-run` | No | `false` | Walk the doc tree and log the plan without making API calls. |
 | `cwd` | No | `${{ github.workspace }}` | Working directory the CLI resolves `folder` against. |

--- a/confluence/action.yml
+++ b/confluence/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: Version-message suffix appended to every page/attachment PUT
     required: false
     default: ''
+  page-title-strategy:
+    description: Leaf page title strategy — filename-stem (default), filename, sentence-case-parent, sentence-case-parents, sentence-case-path. Folder pages keep raw directory names.
+    required: false
+    default: filename-stem
   skip-unchanged:
     description: Skip pages whose body is unchanged (default true)
     required: false
@@ -86,6 +90,7 @@ runs:
       CONFLUENCE_INPUT_SPACE_KEY: ${{ inputs.space-key }}
       CONFLUENCE_INPUT_PARENT_PAGE_ID: ${{ inputs.parent-page-id }}
       CONFLUENCE_INPUT_VERSION_MESSAGE: ${{ inputs.version-message }}
+      CONFLUENCE_INPUT_PAGE_TITLE_STRATEGY: ${{ inputs.page-title-strategy }}
       CONFLUENCE_INPUT_SKIP_UNCHANGED: ${{ inputs.skip-unchanged }}
       CONFLUENCE_INPUT_DRY_RUN: ${{ inputs.dry-run }}
       CONFLUENCE_INPUT_CWD: ${{ inputs.cwd }}

--- a/confluence/run.sh
+++ b/confluence/run.sh
@@ -35,6 +35,9 @@ join_args() {
   if [[ -n "${CONFLUENCE_INPUT_VERSION_MESSAGE:-}" ]]; then
     out+=" --version-message ${CONFLUENCE_INPUT_VERSION_MESSAGE}"
   fi
+  if [[ -n "${CONFLUENCE_INPUT_PAGE_TITLE_STRATEGY:-}" ]]; then
+    out+=" --page-title-strategy ${CONFLUENCE_INPUT_PAGE_TITLE_STRATEGY}"
+  fi
   if [[ "${CONFLUENCE_INPUT_SKIP_UNCHANGED:-true}" == "false" ]]; then
     out+=" --no-skip-unchanged"
   fi

--- a/package.json
+++ b/package.json
@@ -33,9 +33,9 @@
     "@commitlint/config-conventional": "^21.2.2",
     "@commitlint/format": "^21.2.2",
     "@release-it/bumper": "^8.0.0",
-    "@repo-toolkit/changelog": "^0.18.0",
-    "@repo-toolkit/compose-sandbox": "^0.18.0",
-    "@repo-toolkit/confluence": "^0.18.0",
+    "@repo-toolkit/changelog": "^0.20.0",
+    "@repo-toolkit/compose-sandbox": "^0.20.0",
+    "@repo-toolkit/confluence": "^0.20.0",
     "release-it": "^21.0.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,14 +21,14 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0(release-it@21.0.2(@types/node@25.6.0))
       '@repo-toolkit/changelog':
-        specifier: ^0.18.0
-        version: 0.18.0
+        specifier: ^0.20.0
+        version: 0.20.0
       '@repo-toolkit/compose-sandbox':
-        specifier: ^0.18.0
-        version: 0.18.0
+        specifier: ^0.20.0
+        version: 0.20.0
       '@repo-toolkit/confluence':
-        specifier: ^0.18.0
-        version: 0.18.0
+        specifier: ^0.20.0
+        version: 0.20.0
       release-it:
         specifier: ^21.0.2
         version: 21.0.2(@types/node@25.6.0)
@@ -369,23 +369,23 @@ packages:
     peerDependencies:
       release-it: ^18.0.0 || ^19.0.0 || ^20.0.0 || ^21.0.0
 
-  '@repo-toolkit/changelog@0.18.0':
-    resolution: {integrity: sha512-t6ik6GPd0tqBgBxBl088O3aGCHETbGYKjrn0fQuUxKIc1NroEKTdhyyjygdssAx7ueINvF4YOj4Zf/QHmuC21Q==}
+  '@repo-toolkit/changelog@0.20.0':
+    resolution: {integrity: sha512-6eTtap0YGrt2/GyHmzE6YUmc8HBmNZ4Jj33dcoFZRGSvjA4FMzGW2MGarj4jX4NQiRVBIjL0ypVzpsfUPNzW3w==}
     engines: {node: '>=20'}
     hasBin: true
 
-  '@repo-toolkit/compose-sandbox@0.18.0':
-    resolution: {integrity: sha512-M+JR/dbDYnbNxzHTamXbFwLvD1KNaAw1V8cw/qL1Ao1/NsXb22tDWltA8ieiQkE8dcC+r8jaRLzIoi8KH34irQ==}
+  '@repo-toolkit/compose-sandbox@0.20.0':
+    resolution: {integrity: sha512-FA5QoQlSLCc3L10s0RjgjXgCe07Dyj+tnpUThPxpCLkny0Pxa1fNkI98QaFjlAqBt8rV2gH4f4LlkmhzUfq1mg==}
     engines: {node: '>=20'}
     hasBin: true
 
-  '@repo-toolkit/confluence@0.18.0':
-    resolution: {integrity: sha512-0k4qUGzMU74s4/QycIztNkhI68oXHkzjKC4wIO6o0qehEsZRS8ob/vDZlZ+zu0YBWQVmI9bSZrqHxe0BCsNhng==}
+  '@repo-toolkit/confluence@0.20.0':
+    resolution: {integrity: sha512-+zvR5HXOvmgEcTqJC8AktcPMmLmIqInz7h8DrbPWrHZkeKZgEbMnXHSy2MK64/n4p8qrUyv0fWUDE2MZjiXE1g==}
     engines: {node: '>=20'}
     hasBin: true
 
-  '@repo-toolkit/publish-package@0.18.0':
-    resolution: {integrity: sha512-57it/u9E/kX5C9lp/WE2qfSXV/E0MKm8U5R4E2UkWtyhhOnOJqocqCUit2juhWuq6EJB9PTIUK9bjWd0sdQVng==}
+  '@repo-toolkit/publish-package@0.20.0':
+    resolution: {integrity: sha512-x32IqxQFUauJybUvvndzvs7acn5djDCJfS3uOUg8GL27pBz4U+zODN/tvDSbfO/9dSH1/VDtNLHqlzFkwFJIOA==}
     engines: {node: '>=20'}
     hasBin: true
 
@@ -1665,23 +1665,23 @@ snapshots:
       release-it: 21.0.2(@types/node@25.6.0)
       semver: 7.8.5
 
-  '@repo-toolkit/changelog@0.18.0':
+  '@repo-toolkit/changelog@0.20.0':
     dependencies:
-      '@repo-toolkit/publish-package': 0.18.0
+      '@repo-toolkit/publish-package': 0.20.0
       conventional-changelog: 7.2.1
       conventional-changelog-conventionalcommits: 9.3.1
     transitivePeerDependencies:
       - conventional-commits-filter
 
-  '@repo-toolkit/compose-sandbox@0.18.0':
+  '@repo-toolkit/compose-sandbox@0.20.0':
     dependencies:
-      '@repo-toolkit/publish-package': 0.18.0
+      '@repo-toolkit/publish-package': 0.20.0
 
-  '@repo-toolkit/confluence@0.18.0':
+  '@repo-toolkit/confluence@0.20.0':
     dependencies:
-      '@repo-toolkit/publish-package': 0.18.0
+      '@repo-toolkit/publish-package': 0.20.0
 
-  '@repo-toolkit/publish-package@0.18.0':
+  '@repo-toolkit/publish-package@0.20.0':
     dependencies:
       '@clack/prompts': 1.7.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,7 @@
 # gate (e.g. freshly-released @repo-toolkit/* packages that the action needs
 # immediately). Re-run `pnpm install` to refresh; do not format/sort by hand.
 minimumReleaseAgeExclude:
-- '@repo-toolkit/confluence@0.17.0 || 0.18.0'
-- '@repo-toolkit/publish-package@0.17.0 || 0.18.0'
-- '@repo-toolkit/changelog@0.17.0 || 0.18.0'
-- '@repo-toolkit/compose-sandbox@0.17.0 || 0.18.0'
+- '@repo-toolkit/confluence@0.20.0'
+- '@repo-toolkit/publish-package@0.20.0'
+- '@repo-toolkit/changelog@0.20.0'
+- '@repo-toolkit/compose-sandbox@0.20.0'


### PR DESCRIPTION
## Summary

This pull request adds a new `page-title-strategy` input to the Confluence GitHub Action and updates the repo toolkit package versions used by the workspace.

## What changed

### Confluence action updates
- Added a new optional `page-title-strategy` action input with a default of `filename-stem`.
- Passed the input through the action environment so the runner can consume it.
- Updated `run.sh` to forward `--page-title-strategy` when the input is set.
- Documented the new input and its supported values in the README.

### Dependency and workspace updates
- Bumped `@repo-toolkit/changelog`, `@repo-toolkit/compose-sandbox`, and `@repo-toolkit/confluence` from `0.18.0` to `0.20.0` in the root package manifest.
- Refreshed `pnpm-lock.yaml` to match the new toolkit versions and transitive `@repo-toolkit/publish-package` dependency.
- Updated `pnpm-workspace.yaml` minimum release age exclusions to allow the newly released `0.20.0` toolkit packages.

## Notes

The new action option controls how leaf page titles are generated, while folder pages continue to use raw directory names. The README points to the `@repo-toolkit/confluence` naming contract for additional details and migration guidance.

The dependency refresh keeps the workspace aligned with the latest published `@repo-toolkit/*` packages and ensures local installs resolve the same versions as the action updates.