### PR TITLE
Cache pnpm dlx tools and add warm-cache coverage

### DIFF
--- a/pnpm-packages/README.md
+++ b/pnpm-packages/README.md
@@ -4,7 +4,7 @@ Installs dependencies with pnpm for one or more directories that contain a `pack
 
 ## What It Does
 
-- Restores a cache for `**/node_modules` keyed by all `pnpm-lock.yaml` files.
+- Restores a cache for the pnpm store and the dlx cache, keyed by all `pnpm-lock.yaml` files and the `tools` input.
 - Iterates through the configured directories.
 - Runs `pnpm install` in each existing directory.
 - Optionally runs `pnpm install --frozen-lockfile` for strict CI installs.
@@ -65,6 +65,24 @@ jobs:
     ignore-scripts: 'true'
 ```
 
+### Cache Extra CLI Tools (Not in `package.json`)
+
+Tools listed in `tools` are fetched with [`pnpm dlx`](https://pnpm.io/cli/dlx) so the dlx cache is warm for later steps. They are **not** added to any `package.json` or lockfile. Later steps run them with `pnpm dlx <tool> ...`, which then resolves instantly from the cache.
+
+```yaml
+- name: Install dependencies and cache tools
+  uses: egose/actions/pnpm-packages@main
+  with:
+    tools: |
+      turbo
+      apps/web: vite prettier@3
+
+- name: Run a cached tool
+  run: pnpm dlx turbo build
+```
+
+Each line is either a space-separated list of packages (optionally pinned like `name@version`, or with a registry alias) run from the repository root, or prefixed with `path: ` to use a specific directory as the working directory.
+
 ## Inputs
 
 | Name | Required | Default | Description |
@@ -72,12 +90,14 @@ jobs:
 | `paths` | No | `.` | Newline-separated list of directories that contain `package.json` files. |
 | `frozen` | No | `'false'` | Runs `pnpm install --frozen-lockfile` instead of `pnpm install`. |
 | `ignore-scripts` | No | `'false'` | Adds `--ignore-scripts` to the pnpm install command. |
+| `tools` | No | `''` | Newline-separated CLI tools to pre-cache via `pnpm dlx`. Supports an optional `path:` prefix per line. |
 
 ## Notes
 
 - This action does not install Node.js or pnpm. Set those up earlier in the workflow.
 - Missing directories are skipped.
 - The cache key is based on `hashFiles('**/pnpm-lock.yaml')`, so any lockfile change refreshes the cache.
+- The pnpm dlx cache (`${XDG_CACHE_HOME:-~/.cache}/pnpm/dlx`) is cached alongside the pnpm store. A hash of the `tools` input is part of the cache key, so changing the tool set or its versions refreshes the cache.
 - `frozen: 'true'` requires matching `pnpm-lock.yaml` files to already exist for each target directory.
 - `ignore-scripts: 'true'` applies to both normal installs and frozen installs.
 - Installs in a target directory that is itself a pnpm workspace root (i.e. it contains a `pnpm-workspace.yaml`) run as a normal workspace install so the full package set is materialized. Targets that are not workspace roots run with `--ignore-workspace` so each target directory is installed against its own `package.json`/`pnpm-lock.yaml` and pnpm does not walk up to a parent `pnpm-workspace.yaml` to write the lockfile (or install root dependencies) there.

--- a/pnpm-packages/action.yml
+++ b/pnpm-packages/action.yml
@@ -14,6 +14,10 @@ inputs:
     description: Do not run package lifecycle scripts during install
     default: 'false'
     required: false
+  tools:
+    description: CLI tools to cache via pnpm dlx (not added to any package.json)
+    default: ''
+    required: false
 
 runs:
   using: composite
@@ -27,16 +31,22 @@ runs:
         echo "::error::pnpm store path returned an empty path"
         exit 1
       fi
+      dlx_cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/pnpm/dlx"
+      tools_hash="$(printf '%s' "${{ inputs.tools }}" | sha256sum | cut -c1-16)"
       echo "node-version=${node_version#v}" >> "$GITHUB_OUTPUT"
       echo "store-path=$store_path" >> "$GITHUB_OUTPUT"
+      echo "dlx-cache-path=$dlx_cache_dir" >> "$GITHUB_OUTPUT"
+      echo "tools-hash=$tools_hash" >> "$GITHUB_OUTPUT"
     shell: bash
 
   - name: Cache pnpm store
     # see https://github.com/actions/cache/commits/main/
     uses: actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7
     with:
-      path: ${{ steps.cache-metadata.outputs.store-path }}
-      key: pnpm-${{ runner.os }}-node-${{ steps.cache-metadata.outputs.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+      path: |
+        ${{ steps.cache-metadata.outputs.store-path }}
+        ${{ steps.cache-metadata.outputs.dlx-cache-path }}
+      key: pnpm-${{ runner.os }}-node-${{ steps.cache-metadata.outputs.node-version }}-${{ hashFiles('**/pnpm-lock.yaml') }}-tools-${{ steps.cache-metadata.outputs.tools-hash }}
       restore-keys: |
         pnpm-${{ runner.os }}-node-${{ steps.cache-metadata.outputs.node-version }}-
         pnpm-${{ runner.os }}-
@@ -49,3 +59,10 @@ runs:
       PACKAGE_FROZEN: ${{ inputs.frozen }}
       PACKAGE_IGNORE_SCRIPTS: ${{ inputs.ignore-scripts }}
       PACKAGE_PATHS: ${{ inputs.paths }}
+
+  - name: Cache CLI tools
+    if: inputs.tools != ''
+    run: bash "${{ github.action_path }}/../scripts/warm-dlx-cache.sh"
+    shell: bash
+    env:
+      DLX_TOOLS: ${{ inputs.tools }}

--- a/scripts/warm-dlx-cache.sh
+++ b/scripts/warm-dlx-cache.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Warm the pnpm dlx cache for ad-hoc CLI tools that are not declared in any
+# package.json. Each line of DLX_TOOLS is either:
+#   pkg1 pkg2            -> tools cached (run in the workspace root)
+#   some/dir: pkg1 pkg2  -> tools cached with that directory as cwd
+# Warming means downloading the tool into the dlx cache; the tool's own
+# invocation is allowed to fail as long as the download succeeded.
+
+run_tool() {
+  local pkg="$1"
+
+  if pnpm dlx "$pkg" --help > /dev/null 2>&1; then
+    return 0
+  fi
+
+  if pnpm dlx "$pkg" --version > /dev/null 2>&1; then
+    return 0
+  fi
+
+  echo "❌ Failed to cache tool via 'pnpm dlx ${pkg}' in $(pwd)" >&2
+  echo "   Make sure the package name (and version, if pinned) is correct." >&2
+  return 1
+}
+
+workspace_dir="$(pwd)"
+
+while IFS= read -r line || [ -n "$line" ]; do
+  if [ -z "$line" ]; then
+    continue
+  fi
+
+  path='.'
+  pkgs="$line"
+  case "$line" in
+    *:*)
+      path="${line%%:*}"
+      pkgs="${line#*:}"
+      ;;
+  esac
+
+  # shellcheck disable=SC2086 # intentional word splitting for the package list
+  set -- $pkgs
+  if [ "$#" -eq 0 ]; then
+    continue
+  fi
+
+  target="${workspace_dir}/${path}"
+  if [ ! -d "$target" ]; then
+    echo "⚠️ Skipping missing directory: ${path}" >&2
+    continue
+  fi
+
+  cd "$target"
+  for pkg in "$@"; do
+    echo "Caching tool '${pkg}' (${path})"
+    run_tool "$pkg"
+  done
+done <<< "${DLX_TOOLS}"

--- a/tests/test-warm-dlx-cache.sh
+++ b/tests/test-warm-dlx-cache.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "$0")/.." && pwd)"
+workspace="$(mktemp -d)"
+bin_dir="${workspace}/bin"
+log_file="${workspace}/dlx.log"
+
+cleanup() {
+  rm -rf "$workspace"
+}
+
+trap cleanup EXIT
+
+mkdir -p "$bin_dir" "${workspace}/apps/web" "${workspace}/tools"
+
+cat > "${bin_dir}/pnpm" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf 'dlx %s @ %s\n' "\$2" "\$PWD" >> "${log_file}"
+
+# Simulate a tool that fails on --help/--version
+if [ "\$2" = 'broken-cli' ]; then
+  exit 1
+fi
+
+exit 0
+EOF
+chmod 755 "${bin_dir}/pnpm"
+
+run_case() {
+  local dlxtools="$1"
+  local expected_count="$2"
+
+  : > "$log_file"
+  PATH="${bin_dir}:$PATH" \
+  DLX_TOOLS="$dlxtools" \
+  bash -c 'cd "$1" && bash "$2"' _ "$workspace" "${repo_root}/scripts/warm-dlx-cache.sh"
+
+  mapfile -t lines < "$log_file"
+  if [ "${#lines[@]}" -ne "$expected_count" ]; then
+    echo "expected ${expected_count} dlx invocations, got ${#lines[@]}: ${lines[*]:-}"
+    exit 1
+  fi
+}
+
+# Bare package names run in the workspace root
+run_case $'turbo\ncowsay@1 fortune' 3
+
+if [ "${lines[0]}" != "dlx turbo @ ${workspace}" ] || \
+   [ "${lines[1]}" != "dlx cowsay@1 @ ${workspace}" ] || \
+   [ "${lines[2]}" != "dlx fortune @ ${workspace}" ]; then
+  echo "unexpected root invocations: ${lines[*]}"
+  exit 1
+fi
+
+# Path-prefixed entries run with that directory as cwd
+run_case $'apps/web: vite prettier\ntools: eslint' 3
+
+if [ "${lines[0]}" != "dlx vite @ ${workspace}/apps/web" ] || \
+   [ "${lines[1]}" != "dlx prettier @ ${workspace}/apps/web" ] || \
+   [ "${lines[2]}" != "dlx eslint @ ${workspace}/tools" ]; then
+  echo "unexpected path-scoped invocations: ${lines[*]}"
+  exit 1
+fi
+
+# Blank lines are skipped and missing directories are skipped
+run_case $'\nmissing/dir: foo\n turbo ' 1
+
+# A tool that fails both --help and --version must fail the script
+if PATH="${bin_dir}:$PATH" DLX_TOOLS='broken-cli' \
+  bash -c 'cd "$1" && bash "$2"' _ "$workspace" "${repo_root}/scripts/warm-dlx-cache.sh" 2>/dev/null; then
+  echo "expected failure for broken-cli"
+  exit 1
+fi
+
+echo "warm-dlx-cache tests passed"


### PR DESCRIPTION
## Summary

This change extends the pnpm packages action to pre-cache ad-hoc CLI tools fetched with `pnpm dlx`, alongside the existing pnpm store cache.

## What changed

### Action updates
- Adds a new optional `tools` input for listing CLI tools to warm via `pnpm dlx`.
- Includes the pnpm dlx cache directory in the cached paths.
- Adds the `tools` hash to the cache key so changes to the tool list or versions invalidate the cache appropriately.
- Runs a new helper script to warm the dlx cache when `tools` is provided.

### New cache warming script
- Adds `scripts/warm-dlx-cache.sh` to parse newline-separated tool definitions.
- Supports both:
  - root-scoped tool lists like `turbo` or `vite prettier@3`
  - path-scoped tool lists like `apps/web: vite prettier`
- Skips missing directories and empty lines.
- Verifies the tool can be resolved by attempting a `pnpm dlx` invocation.

### Documentation
- Updates the README to explain the new `tools` input and how to use cached `pnpm dlx` tools later in workflows.
- Documents the pnpm dlx cache behavior and how the cache key is affected by tool changes.

### Tests
- Adds coverage for root-scoped tool caching.
- Adds coverage for path-scoped tool caching.
- Verifies blank lines and missing directories are skipped.
- Verifies a tool that cannot be warmed causes the script to fail.

## Notes

This keeps `pnpm dlx` tools out of `package.json` while still making them available quickly in later workflow steps.